### PR TITLE
Actually return fall-back field stringification

### DIFF
--- a/reversion_compare/admin.py
+++ b/reversion_compare/admin.py
@@ -72,7 +72,7 @@ class CompareObject(object):
         if isinstance(self.value, basestring):
             return self.value
         else:
-            self._obj_repr(self.value)
+            return self._obj_repr(self.value)
 
     def __cmp__(self, other):
         raise NotImplemented()


### PR DESCRIPTION
Discovered when trying to diff an IntegerField; bug: shows "None" instead of the field diff.
