### PR TITLE
Reverse foreign key

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,4 +15,5 @@ CONTRIBUTORS are and/or have been (alphabetic order):
   Github: <https://github.com/bmihelac> 
 * Pahaz, Blinov
   Github: <https://github.com/pahaz>
-
+* Spencer, Samuel
+  Github: <https://github.com/LegoStormtroopr>

--- a/reversion_compare/templates/reversion-compare/compare.html
+++ b/reversion_compare/templates/reversion-compare/compare.html
@@ -16,8 +16,8 @@
 
 {% block breadcrumbs %}
     <div class="breadcrumbs">
-        <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> &rsaquo; 
-        <a href="{% url "admin:app_list" app_label %}">{{app_label|capfirst|escape}}</a> &rsaquo; 
+        <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> &rsaquo;
+        <a href="{% url "admin:app_list" app_label %}">{{app_label|capfirst|escape}}</a> &rsaquo;
         <a href="{{changelist_url}}">{{opts.verbose_name_plural|capfirst}}</a> &rsaquo;
         <a href="{{history_url}}">{% trans "History" %}</a> &rsaquo;
         {% blocktrans with opts.verbose_name_plural|escape as name %}Compare {{name}}{% endblocktrans %}
@@ -37,7 +37,7 @@
               {% endblock %}
             </ul>
         {% endblock %}
-        
+
         <p class="help">
             {% blocktrans with date1=version1.revision.date_created|date:_("DATETIME_FORMAT") date2=version2.revision.date_created|date:_("DATETIME_FORMAT") %}
                 Compare <strong>{{ date1 }}</strong> with <strong>{{ date2 }}</strong>:
@@ -45,7 +45,7 @@
         </p>
         &lsaquo; <a href="{{history_url}}">{% trans "Go back to history list" %}</a>
         {% for field_diff in compare_data %}
-            <h3>{{ field_diff.field.verbose_name }}{% if field_diff.is_related and not field_diff.follow %}<sup class="follow">*</sup>{% endif %}</h3>
+            <h3>{% firstof field_diff.field.verbose_name field_diff.field.related_name %}{% if field_diff.is_related and not field_diff.follow %}<sup class="follow">*</sup>{% endif %}</h3>
             {% if field_diff.field.help_text %}<p class="help">{{ field_diff.field.help_text }}</p>{% endif %}
             <div class="module">
                 <p>{{ field_diff.diff }}</p>
@@ -55,10 +55,10 @@
                 <p><strong>There are no differences.</strong></p>
             </div>
         {% endfor %}
-        
+
         <h4>{% trans "Edit comment:" %}</h4>
         <blockquote>{{ version2.revision.comment|default:"(there exist not comment)" }}</blockquote>
-        
+
         {% if has_unfollowed_fields %}
         <h4 class="follow">{% trans "Note:" %}</h4>
         <p class="follow">

--- a/reversion_compare_test_project/manage.py
+++ b/reversion_compare_test_project/manage.py
@@ -1,20 +1,13 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-import os
+import os,sys
+
+BASE = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(1,os.path.join(BASE, "../"))
 
 os.environ['DJANGO_SETTINGS_MODULE'] = "reversion_compare_test_project.settings"
 
-from django.core.management import execute_manager
-import imp
-try:
-    imp.find_module('settings') # Assumed to be in the same directory.
-except ImportError:
-    import sys
-    sys.stderr.write("Error: Can't find the file 'settings.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n" % __file__)
-    sys.exit(1)
-
-import settings
-
 if __name__ == "__main__":
-    execute_manager(settings)
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)


### PR DESCRIPTION
Still needs appropriate tests for the new, just submitting the request as an FYI. There is a little more work that needs to be done to write the tests.

The reverse foreign key (ManyToOne) behaves very similar to the ManyToOne, so it reuses a lot of that code. However, the `related` property doesn't have a `get_internal_type` or `rel` methods, hence the extra checks.