### PR TITLE
Update admin.py to avoid RemovedInDjango19Warning

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,3 +17,6 @@ CONTRIBUTORS are and/or have been (alphabetic order):
   Github: <https://github.com/pahaz>
 * Spencer, Samuel
   Github: <https://github.com/LegoStormtroopr>
+* C. Barrionuevo da Luz, Fabio
+  Github: <https://github.com/luzfcb>
+  

--- a/reversion_compare/admin.py
+++ b/reversion_compare/admin.py
@@ -20,7 +20,10 @@ from reversion.models import has_int_pk
 
 from django import template
 from django.conf.urls import patterns, url
-from django.contrib.admin.util import unquote, quote
+try:
+    from django.contrib.admin.utils import unquote, quote
+except ImportError:  # Django < 1.7
+    from django.contrib.admin.util import unquote, quote
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.http import Http404


### PR DESCRIPTION
Django 1.8 shows the error message:

```
(testapp)luzfcb@luzfcb:~/projects/testapp$ python manage.py check
/home/luzfcb/virtualenvs/testapp/lib/python3.4/site-packages/django/contrib/admin/util.py:7: RemovedInDjango19Warning: The django.contrib.admin.util module has been renamed. Use django.contrib.admin.utils instead.
  "Use django.contrib.admin.utils instead.", RemovedInDjango19Warning)

System check identified no issues (0 silenced).

```
because in django 1.9, the module `django.contrib.admin.util` was renamed `django.contrib.admin.utils`