### PR TITLE
One to one field custom related name fix

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,4 +19,5 @@ CONTRIBUTORS are and/or have been (alphabetic order):
   Github: <https://github.com/LegoStormtroopr>
 * C. Barrionuevo da Luz, Fabio
   Github: <https://github.com/luzfcb>
-  
+* Wickström, Frank
+  Github: <https://github.com/frwickst>

--- a/reversion_compare/admin.py
+++ b/reversion_compare/admin.py
@@ -25,6 +25,7 @@ try:
 except ImportError:  # Django < 1.7
     from django.contrib.admin.util import unquote, quote
 from django.core.urlresolvers import reverse
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.http import Http404
 from django.contrib import admin
@@ -108,7 +109,14 @@ class CompareObject(object):
         obj = self.version.object_version.object
         # self = getattr(obj, self.field.related_name) #self.field.field_name
         if self.has_int_pk and self.field.related_name and hasattr(obj, self.field.related_name):
-            ids = [v.id for v in getattr(obj, str(self.field.related_name)).all()]  # is: version.field_dict[field.name]
+            if isinstance(self.field, models.fields.related.OneToOneRel):
+                try:
+                    ids = [getattr(obj, str(self.field.related_name)).pk]
+                except ObjectDoesNotExist:
+                    ids = []
+            else:
+                ids = [v.id for v in getattr(obj, str(self.field.related_name)).all()]  # is: version.field_dict[field.name]
+
         else:
             return ([], [], [], [])  # TODO: refactory that
 

--- a/reversion_compare/admin.py
+++ b/reversion_compare/admin.py
@@ -107,7 +107,6 @@ class CompareObject(object):
 
     def get_reverse_foreign_key(self):
         obj = self.version.object_version.object
-        # self = getattr(obj, self.field.related_name) #self.field.field_name
         if self.has_int_pk and self.field.related_name and hasattr(obj, self.field.related_name):
             if isinstance(self.field, models.fields.related.OneToOneRel):
                 try:

--- a/tests/admin.py
+++ b/tests/admin.py
@@ -20,7 +20,7 @@ from django.contrib import admin
 from reversion_compare.admin import CompareVersionAdmin
 
 from .models import SimpleModel, Factory, Car, Person, Pet,\
-    VariantModel, CustomModel
+    VariantModel, CustomModel, Identity
 
 
 
@@ -58,6 +58,7 @@ class CustomModelAdmin(CompareVersionAdmin):
     revision_manager = custom_revision_manager
 admin.site.register(CustomModel, CustomModelAdmin)
 
+admin.site.register(Identity, CustomModelAdmin)
 
 
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -77,6 +77,13 @@ class Person(models.Model):
     def __str__(self):
         return self.name
 
+@python_2_unicode_compatible
+class Identity(models.Model):
+    id_numer = models.CharField(max_length=100)
+    person = models.OneToOneField(Person, related_name='_identity')
+    def __str__(self):
+        return self.id_numer
+
 reversion.register(Person, follow=["pets"])
 #reversion.register(Pet, follow=["person_set"])
 reversion.register(Pet)

--- a/tests/test_onetoone_field.py
+++ b/tests/test_onetoone_field.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+"""
+    django-reversion-compare unittests
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    I used the setup from reversion_compare_test_project !
+
+    TODO:
+        * models.IntegerField()
+
+    :copyleft: 2012-2015 by the django-reversion-compare team, see AUTHORS for more details.
+    :license: GNU GPL v3 or above, see LICENSE for more details.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+
+try:
+    import django_tools
+except ImportError as err:
+    msg = (
+        "Please install django-tools for unittests"
+        " - https://github.com/jedie/django-tools/"
+        " - Original error: %s"
+    ) % err
+    raise ImportError(msg)
+
+from reversion import get_for_object
+
+from .test_utils.test_cases import BaseTestCase
+from .test_utils.test_data import TestData
+
+
+class OneToOneFieldTest(BaseTestCase):
+    "Test a model which uses a custom reversion manager."
+
+    def setUp(self):
+        super(OneToOneFieldTest, self).setUp()
+        test_data = TestData(verbose=False)
+        self.person, self.item = test_data.create_PersonIdentity_data()
+
+        queryset = get_for_object(self.person)
+        self.version_ids = queryset.values_list("pk", flat=True)
+
+    def test_select_compare(self):
+        response = self.client.get("/admin/tests/person/%s/history/" % self.person.pk)
+
+        self.assertContainsHtml(response,
+            '<input type="submit" value="compare">',
+            '<input type="radio" name="version_id1" value="%i" style="visibility:hidden" />' % self.version_ids[0],
+            '<input type="radio" name="version_id2" value="%i" checked="checked" />' % self.version_ids[0],
+            '<input type="radio" name="version_id1" value="%i" checked="checked" />' % self.version_ids[1],
+            '<input type="radio" name="version_id2" value="%i" />' % self.version_ids[1],
+        )
+
+    def test_compare(self):
+        response = self.client.get(
+            "/admin/tests/person/%s/history/compare/" % self.person.pk,
+            data={"version_id2":self.version_ids[0], "version_id1":self.version_ids[1]}
+        )
+
+        self.assertContainsHtml(response,
+            """
+            <pre class="highlight">
+                <del>- Dave</del>
+                <ins>+ John</ins>
+            </pre>
+            """,
+            "<blockquote>version 2: change person name.</blockquote>",
+        )

--- a/tests/test_utils/test_data.py
+++ b/tests/test_utils/test_data.py
@@ -38,7 +38,7 @@ except ImportError as err:
 import reversion
 
 from tests.models import SimpleModel, Person, Pet, \
-    Factory, Car, VariantModel, CustomModel
+    Factory, Car, VariantModel, CustomModel, Identity
 
 
 
@@ -367,4 +367,20 @@ class TestData(object):
             print("version 1:", item1)
 
         return item1
+
+
+    def create_PersonIdentity_data(self):
+        with reversion.create_revision():
+            person = Person.objects.create(name="Dave")
+            identity = Identity.objects.create(id_numer="1234", person=person)
+
+        if self.verbose:
+            print("version 1:", person, identity)
+
+        with reversion.create_revision():
+            person.name = "John"
+            person.save()
+            reversion.set_comment("version 2: change person name.")
+
+        return person, identity
 


### PR DESCRIPTION
The code is almost the same as @aemdy fix, https://github.com/aemdy/django-reversion-compare/commit/da60d7873bbd8fb212f7f076a68b0b52e297796e. Just a bit more nicely structured and with a proper commit message.

This should fix: #36

Note that there are other problems in the code base that will most likely cause a comparison to still fail, such as #41.