### PR TITLE
Admin history/view for non-admin views (issue #46)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,8 @@ CONTRIBUTORS are and/or have been (alphabetic order):
   Github: <https://github.com/bmihelac> 
 * Pahaz, Blinov
   Github: <https://github.com/pahaz>
+* Papastefanos, Serafeim
+  Github: <https://github.com/spapas>  
 * Spencer, Samuel
   Github: <https://github.com/LegoStormtroopr>
 * C. Barrionuevo da Luz, Fabio

--- a/README.creole
+++ b/README.creole
@@ -58,8 +58,8 @@ class ExampleModelAdmin(CompareVersionAdmin):
 admin.site.register(ExampleModel, ExampleModelAdmin)
 }}}
 
-If you're using an existing third party app, then you can add patch django-reversion-compare into 
-its admin class by using the **reversion_compare.helpers.patch_admin()** method. For example, to add 
+If you're using an existing third party app, then you can add patch django-reversion-compare into
+its admin class by using the **reversion_compare.helpers.patch_admin()** method. For example, to add
 version control to the built-in User model:
 
 {{{
@@ -110,52 +110,52 @@ Beyond the admin views, you can also create a class based view for displaying an
 differences. This is a single class-based-view that either dispalys the list of versions to select
 for an object or displays both the versions *and* their differences (if the versions to be compared
 have been selected). This class can be used just like a normal DetailView:
-    
+
 Inherit from it in your class and add a model (or queryset), for example:
 
-{{{    
+{{{
 class SimpleModelHistoryCompareView(HistoryCompareDetailView):
     model = SimpleModel
 }}}
 
-    Then, assign that CBV to a url, for example : 
+Then, assign that CBV to a url, for example:
 
 {{{
-    url(r'^test_view/(?P<pk>\d+)$', views.SimpleModelHistoryCompareView.as_view() ),
+url(r'^test_view/(?P<pk>\d+)$', views.SimpleModelHistoryCompareView.as_view() ),
 }}}
-    
-Last step, you need to create a template to display both the version select form and 
+
+Last step, you need to create a template to display both the version select form and
 the changes part (if the form is submitted). An example template is the following:
 
 {{{
-    <style type="text/css">
-    /* minimal style for the diffs */
-    del, ins {
-        color: #000;
-        text-decoration: none;
-    }
-    del { background-color: #ffe6e6; }
-    ins { background-color: #e6ffe6; }
-    sup.follow { color: #5555ff; }
-    </style>
+<style type="text/css">
+/* minimal style for the diffs */
+del, ins {
+    color: #000;
+    text-decoration: none;
+}
+del { background-color: #ffe6e6; }
+ins { background-color: #e6ffe6; }
+sup.follow { color: #5555ff; }
+</style>
 
-    {% include "reversion-compare/action_list_partial.html"  %}
-    {% include "reversion-compare/compare_partial.html"  %}
-    {% include "reversion-compare/compare_links_partial.html"  %}
+{% include "reversion-compare/action_list_partial.html"  %}
+{% include "reversion-compare/compare_partial.html"  %}
+{% include "reversion-compare/compare_links_partial.html"  %}
 }}}
-    
-Beyond the styling, you should include 
-- reversion-compare/action_list_partial.html partial template to display the version select form
-- reversion-compare/compare_partial.html partial template to display the actual version
-- reversion-compare/compare_links_partial.html to include previous/next comparison links
-    
+
+Beyond the styling, you should include
+* reversion-compare/action_list_partial.html partial template to display the version select form
+* reversion-compare/compare_partial.html partial template to display the actual version
+* reversion-compare/compare_links_partial.html to include previous/next comparison links
+
 If you want more control on the appearence of your templates you can check the above partials
 to understand how the availabble context variables are used and override them completely.
 
 
 == screenshots ==
 
-Here some screenshots of django-reversion-compare: 
+Here some screenshots of django-reversion-compare:
 
 ----
 
@@ -177,7 +177,7 @@ from **v0.1.0**: Same as above, but the are more lines changed in TextField and 
 
 ----
 
-Example screenshot from **v0.3.0**: a many-to-many field compare (friends, hobbies): 
+Example screenshot from **v0.3.0**: a many-to-many field compare (friends, hobbies):
 
 {{http://www.pylucid.org/static/pylucid.org/screenshots_PyLucid/django-reversion/django-reversion-compare_v0_3_0-01.png|django-reversion-compare_v0_3_0-01.png}}
 

--- a/README.creole
+++ b/README.creole
@@ -108,7 +108,7 @@ patch_admin(User, AdminClass=YourAdmin)
 
 Beyond the admin views, you can also create a class based view for displaying and comparing version
 differences. This is a single class-based-view that either dispalys the list of versions to select
-for an object or displays both the versions *and* their differences (if the versions to be compared
+for an object or displays both the versions **and** their differences (if the versions to be compared
 have been selected). This class can be used just like a normal DetailView:
 
 Inherit from it in your class and add a model (or queryset), for example:

--- a/README.creole
+++ b/README.creole
@@ -104,6 +104,55 @@ patch_admin(User, AdminClass=YourAdmin)
 }}}
 
 
+== Class-Based-View ==
+
+Beyond the admin views, you can also create a class based view for displaying and comparing version
+differences. This is a single class-based-view that either dispalys the list of versions to select
+for an object or displays both the versions *and* their differences (if the versions to be compared
+have been selected). This class can be used just like a normal DetailView:
+    
+Inherit from it in your class and add a model (or queryset), for example:
+
+{{{    
+class SimpleModelHistoryCompareView(HistoryCompareDetailView):
+    model = SimpleModel
+}}}
+
+    Then, assign that CBV to a url, for example : 
+
+{{{
+    url(r'^test_view/(?P<pk>\d+)$', views.SimpleModelHistoryCompareView.as_view() ),
+}}}
+    
+Last step, you need to create a template to display both the version select form and 
+the changes part (if the form is submitted). An example template is the following:
+
+{{{
+    <style type="text/css">
+    /* minimal style for the diffs */
+    del, ins {
+        color: #000;
+        text-decoration: none;
+    }
+    del { background-color: #ffe6e6; }
+    ins { background-color: #e6ffe6; }
+    sup.follow { color: #5555ff; }
+    </style>
+
+    {% include "reversion-compare/action_list_partial.html"  %}
+    {% include "reversion-compare/compare_partial.html"  %}
+    {% include "reversion-compare/compare_links_partial.html"  %}
+}}}
+    
+Beyond the styling, you should include 
+- reversion-compare/action_list_partial.html partial template to display the version select form
+- reversion-compare/compare_partial.html partial template to display the actual version
+- reversion-compare/compare_links_partial.html to include previous/next comparison links
+    
+If you want more control on the appearence of your templates you can check the above partials
+to understand how the availabble context variables are used and override them completely.
+
+
 == screenshots ==
 
 Here some screenshots of django-reversion-compare: 

--- a/reversion_compare/admin.py
+++ b/reversion_compare/admin.py
@@ -14,450 +14,30 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 
-import reversion
-from reversion.admin import VersionAdmin
-from reversion.models import has_int_pk
-
 from django import template
+from django.conf import settings
 from django.conf.urls import patterns, url
+from django.contrib import admin
 try:
     from django.contrib.admin.utils import unquote, quote
 except ImportError:  # Django < 1.7
     from django.contrib.admin.util import unquote, quote
 from django.core.urlresolvers import reverse
-from django.core.exceptions import ObjectDoesNotExist
-from django.db import models
 from django.http import Http404
-from django.contrib import admin
 from django.shortcuts import get_object_or_404, render_to_response
-from django.template.loader import render_to_string
 from django.utils.text import capfirst
 from django.utils.translation import ugettext as _
-from reversion_compare.forms import SelectDiffForm
-from reversion_compare.helpers import html_diff
-from django.conf import settings
-from django.contrib.contenttypes.models import ContentType
 
+import reversion
+from reversion.admin import VersionAdmin
+
+from reversion_compare.forms import SelectDiffForm
+from reversion_compare.mixins import CompareMixin, CompareMethodsMixin
 
 logger = logging.getLogger(__name__)
 
 
-class CompareObject(object):
-    def __init__(self, field, field_name, obj, version, has_int_pk, adapter):
-        self.field = field
-        self.field_name = field_name
-        self.obj = obj
-        self.version = version  # instance of reversion.models.Version()
-        self.has_int_pk = has_int_pk
-        self.adapter = adapter
-        # try and get a value, if none punt
-        self.value = version.field_dict.get(field_name, _("Field Didn't exist!"))
-
-    def _obj_repr(self, obj):
-        # FIXME: How to create a better representation of the current value?
-        try:
-            return str(obj)
-        except Exception as e:
-            return repr(obj)
-
-    def _to_string_ManyToManyField(self):
-        queryset = self.get_many_to_many()
-        return ", ".join([self._obj_repr(item) for item in queryset])
-
-    def _to_string_ForeignKey(self):
-        obj = self.get_related()
-        return self._obj_repr(obj)
-
-    def to_string(self):
-        internal_type = self.field.get_internal_type()
-        func_name = "_to_string_%s" % internal_type
-        if hasattr(self, func_name):
-            func = getattr(self, func_name)
-            return func()
-
-        if isinstance(self.value, str):
-            return self.value
-        else:
-            return self._obj_repr(self.value)
-
-    def __cmp__(self, other):
-        raise NotImplemented()
-
-    def __eq__(self, other):
-        if hasattr(self.field, 'get_internal_type'):
-            assert self.field.get_internal_type() != "ManyToManyField"
-
-        if self.value != other.value:
-            return False
-
-        if not hasattr(self.field, 'get_internal_type') or self.field.get_internal_type() == "ForeignKey":  # FIXME!
-            if self.version.field_dict != other.version.field_dict:
-                return False
-
-        return True
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
-    def get_related(self):
-        if getattr(self.field, 'rel', None):
-            obj = self.version.object_version.object
-            try:
-                return getattr(obj, self.field.name, None)
-            except ObjectDoesNotExist:
-                return None
-
-    def get_reverse_foreign_key(self):
-        obj = self.version.object_version.object
-        if self.has_int_pk and self.field.related_name and hasattr(obj, self.field.related_name):
-            if isinstance(self.field, models.fields.related.OneToOneRel):
-                try:
-                    ids = [getattr(obj, str(self.field.related_name)).pk]
-                except ObjectDoesNotExist:
-                    ids = []
-            else:
-                ids = [v.id for v in getattr(obj, str(self.field.related_name)).all()]  # is: version.field_dict[field.name]
-
-        else:
-            return ([], [], [], [])  # TODO: refactory that
-
-        # Get the related model of the current field:
-        related_model = self.field.field.model
-        return self.get_many_to_something(ids, related_model, is_reverse=True)
-
-    def get_many_to_many(self):
-        """
-        returns a queryset with all many2many objects
-        """
-        if self.field.get_internal_type() != "ManyToManyField":  # FIXME!
-            return ([], [], [], [])  # TODO: refactory that
-        ids = None
-        if self.has_int_pk:
-            ids = [int(v) for v in self.value]  # is: version.field_dict[field.name]
-
-        # Get the related model of the current field:
-        related_model = self.field.rel.to
-        return self.get_many_to_something(ids, related_model)
-
-    def get_many_to_something(self, ids, related_model, is_reverse=False):
-
-        # get instance of reversion.models.Revision():
-        # A group of related object versions.
-        old_revision = self.version.revision
-
-        # Get a queryset with all related objects.
-        versions = old_revision.version_set.filter(
-            content_type=ContentType.objects.get_for_model(related_model),
-            object_id__in=ids
-        )
-
-        if self.has_int_pk:
-            # The primary_keys would be stored in a text field -> convert it to integers
-            # This is interesting in different places!
-            for version in versions:
-                version.object_id = int(version.object_id)
-
-        missing_objects = []
-        missing_ids = []
-
-        if self.field_name not in self.adapter.follow:
-            # This models was not registered with follow relations
-            # Try to fill missing related objects
-            target_ids = set(ids)
-            actual_ids = set([version.object_id for version in versions])
-            missing_ids1 = target_ids.difference(actual_ids)
-
-            # logger.debug(self.field_name, "target: %s - actual: %s - missing: %s" % (target_ids, actual_ids, missing_ids1))
-            if missing_ids1:
-                missing_objects = related_model.objects.all().filter(pk__in=missing_ids1)
-                missing_ids = list(target_ids.difference(set(missing_objects.values_list('pk', flat=True))))
-
-        deleted = []
-        if is_reverse:
-            true_missing_objects = []
-            for o in missing_objects:
-                for ver in reversion.get_for_object(o):
-                    # An object can only be missing if it actually existed prior to this version
-                    # Otherwise its a new item
-                    if ver.revision.date_created < old_revision.date_created:
-                        true_missing_objects.append(o)
-            missing_objects = true_missing_objects
-            deleted = [d for d in reversion.get_deleted(related_model) if d.revision == old_revision]
-        return versions, missing_objects, missing_ids, deleted
-
-    def get_debug(self):
-        if not settings.DEBUG:
-            return
-
-        result = [
-            "field..............: %r" % self.field,
-            "field_name.........: %r" % self.field_name,
-            "field internal type: %r" % self.field.get_internal_type(),
-            "field_dict.........: %s" % repr(self.version.field_dict),
-            "adapter............: %r (follow: %r)" % (self.adapter, ", ".join(self.adapter.follow)),
-            "has_int_pk ........: %r" % self.has_int_pk,
-            "obj................: %r (pk: %s, id: %s)" % (self.obj, self.obj.pk, id(self.obj)),
-            "version............: %r (pk: %s, id: %s)" % (self.version, self.version.pk, id(self.version)),
-            "value..............: %r" % self.value,
-            "to string..........: %s" % repr(self.to_string()),
-            "related............: %s" % repr(self.get_related()),
-        ]
-        m2m_versions, missing_objects, missing_ids, deleted = self.get_many_to_many()
-        if m2m_versions or missing_objects or missing_ids:
-            result.append(
-                "many-to-many.......: %s" % ", ".join(
-                    ["%s (%s)" % (
-                        item,
-                        item.type
-                    ) for item in m2m_versions]
-                )
-            )
-
-            if missing_objects:
-                result.append("missing m2m objects: %s" % repr(missing_objects))
-            else:
-                result.append("missing m2m objects: (has no)")
-
-            if missing_ids:
-                result.append("missing m2m IDs....: %s" % repr(missing_ids))
-            else:
-                result.append("missing m2m IDs....: (has no)")
-        else:
-            result.append("many-to-many.......: (has no)")
-
-        return result
-
-    def debug(self):
-        if not settings.DEBUG:
-            return
-        for item in self.get_debug():
-            logger.debug(item)
-
-
-class CompareObjects(object):
-    def __init__(self, field, field_name, obj, version1, version2, manager, is_reversed):
-        self.field = field
-        self.field_name = field_name
-        self.obj = obj
-
-        model = self.obj.__class__
-        self.has_int_pk = has_int_pk(model)
-        self.adapter = manager.get_adapter(model)  # VersionAdapter instance
-
-        # is a related field (ForeignKey, ManyToManyField etc.)
-        self.is_related = getattr(self.field, 'rel', None) is not None
-        self.is_reversed = is_reversed
-        if not self.is_related:
-            self.follow = None
-        elif self.field_name in self.adapter.follow:
-            self.follow = True
-        else:
-            self.follow = False
-
-        self.compare_obj1 = CompareObject(field, field_name, obj, version1, self.has_int_pk, self.adapter)
-        self.compare_obj2 = CompareObject(field, field_name, obj, version2, self.has_int_pk, self.adapter)
-
-        self.value1 = self.compare_obj1.value
-        self.value2 = self.compare_obj2.value
-
-    def changed(self):
-        """ return True if at least one field has changed values. """
-
-        info = None
-        if hasattr(self.field, 'get_internal_type') and self.field.get_internal_type() == "ManyToManyField":
-            info = self.get_m2m_change_info()
-        elif self.is_reversed:
-            info = self.get_m2o_change_info()
-        if info:
-            keys = (
-                "changed_items", "removed_items", "added_items",
-                "removed_missing_objects", "added_missing_objects", 'deleted_items'
-            )
-            for key in keys:
-                if info[key]:
-                    return True
-            return False
-
-        return self.compare_obj1 != self.compare_obj2
-
-    def _get_result(self, compare_obj, func_name):
-        func = getattr(compare_obj, func_name)
-        result = func()
-        return result
-
-    def _get_both_results(self, func_name):
-        result1 = self._get_result(self.compare_obj1, func_name)
-        result2 = self._get_result(self.compare_obj2, func_name)
-        return (result1, result2)
-
-    def to_string(self):
-        return self._get_both_results("to_string")
-
-    def get_related(self):
-        return self._get_both_results("get_related")
-
-    def get_many_to_many(self):
-        # return self._get_both_results("get_many_to_many")
-        m2m_data1, m2m_data2 = self._get_both_results("get_many_to_many")
-        return m2m_data1, m2m_data2
-
-    def get_reverse_foreign_key(self):
-        return self._get_both_results("get_reverse_foreign_key")
-
-    M2O_CHANGE_INFO = None
-
-    def get_m2o_change_info(self):
-        if self.M2O_CHANGE_INFO is not None:
-            return self.M2O_CHANGE_INFO
-
-        m2o_data1, m2o_data2 = self.get_reverse_foreign_key()
-
-        self.M2O_CHANGE_INFO = self.get_m2s_change_info(m2o_data1, m2o_data2)
-        return self.M2O_CHANGE_INFO
-
-    M2M_CHANGE_INFO = None
-
-    def get_m2m_change_info(self):
-        if self.M2M_CHANGE_INFO is not None:
-            return self.M2M_CHANGE_INFO
-
-        m2m_data1, m2m_data2 = self.get_many_to_many()
-
-        self.M2M_CHANGE_INFO = self.get_m2s_change_info(m2m_data1, m2m_data2)
-        return self.M2M_CHANGE_INFO
-
-    # Abstract Many-to-Something (either -many or -one) as both
-    # many2many and many2one relationships looks the same from the refered object.
-    def get_m2s_change_info(self, obj1_data, obj2_data):
-
-        result1, missing_objects1, missing_ids1, deleted1 = obj1_data
-        result2, missing_objects2, missing_ids2, deleted2 = obj2_data
-
-        # missing_objects_pk1 = [obj.pk for obj in missing_objects1]
-        #        missing_objects_pk2 = [obj.pk for obj in missing_objects2]
-        missing_objects_dict2 = dict([(obj.pk, obj) for obj in missing_objects2])
-
-        # logger.debug("missing_objects1: %s", missing_objects1)
-        # logger.debug("missing_objects2: %s", missing_objects2)
-        # logger.debug("missing_ids1: %s", missing_ids1)
-        # logger.debug("missing_ids2: %s", missing_ids2)
-
-        missing_object_set1 = set(missing_objects1)
-        missing_object_set2 = set(missing_objects2)
-        # logger.debug("%s %s", missing_object_set1, missing_object_set2)
-
-        same_missing_objects = missing_object_set1.intersection(missing_object_set2)
-        removed_missing_objects = missing_object_set1.difference(missing_object_set2)
-        added_missing_objects = missing_object_set2.difference(missing_object_set1)
-
-        # logger.debug("same_missing_objects: %s", same_missing_objects)
-        # logger.debug("removed_missing_objects: %s", removed_missing_objects)
-        # logger.debug("added_missing_objects: %s", added_missing_objects)
-
-
-        # Create same_items, removed_items, added_items with related m2m items
-
-        changed_items = []
-        removed_items = []
-        added_items = []
-        same_items = []
-
-        primary_keys1 = [version.object_id for version in result1]
-        primary_keys2 = [version.object_id for version in result2]
-
-        result_dict1 = dict([(version.object_id, version) for version in result1])
-        result_dict2 = dict([(version.object_id, version) for version in result2])
-
-        # logger.debug(result_dict1)
-        # logger.debug(result_dict2)
-
-        for primary_key in set(primary_keys1).union(set(primary_keys2)):
-            if primary_key in result_dict1:
-                version1 = result_dict1[primary_key]
-            else:
-                version1 = None
-
-            if primary_key in result_dict2:
-                version2 = result_dict2[primary_key]
-            else:
-                version2 = None
-
-            #logger.debug("%r - %r - %r", primary_key, version1, version2)
-
-            if version1 is not None and version2 is not None:
-                # In both -> version changed or the same
-                if version1.serialized_data == version2.serialized_data:
-                    #logger.debug("same item: %s", version1)
-                    same_items.append(version1)
-                else:
-                    changed_items.append((version1, version2))
-            elif version1 is not None and version2 is None:
-                # In 1 but not in 2 -> removed
-                #logger.debug("%s %s", primary_key, missing_objects_pk2)
-                #logger.debug("%s %s", repr(primary_key), repr(missing_objects_pk2))
-                if primary_key in missing_objects_dict2:
-                    missing_object = missing_objects_dict2[primary_key]
-                    added_missing_objects.remove(missing_object)
-                    same_missing_objects.add(missing_object)
-                    continue
-
-                removed_items.append(version1)
-            elif version1 is None and version2 is not None:
-                # In 2 but not in 1 -> added
-                #logger.debug("added: %s", version2)
-                added_items.append(version2)
-            else:
-                raise RuntimeError()
-
-        return {
-            "changed_items": changed_items,
-            "removed_items": removed_items,
-            "added_items": added_items,
-            "same_items": same_items,
-            "same_missing_objects": same_missing_objects,
-            "removed_missing_objects": removed_missing_objects,
-            "added_missing_objects": added_missing_objects,
-            "deleted_items": deleted1,
-        }
-
-
-    def debug(self):
-        if not settings.DEBUG:
-            return
-        logger.debug("_______________________________")
-        logger.debug(" *** CompareObjects debug: ***")
-        logger.debug("changed: %s", self.changed())
-        logger.debug("follow: %s", self.follow)
-
-        debug1 = self.compare_obj1.get_debug()
-        debug2 = self.compare_obj2.get_debug()
-        debug_set1 = set(debug1)
-        debug_set2 = set(debug2)
-
-        logger.debug(" *** same attributes/values in obj1 and obj2: ***")
-        intersection = debug_set1.intersection(debug_set2)
-        for item in debug1:
-            if item in intersection:
-                logger.debug(item)
-
-        logger.debug(" -" * 40)
-        logger.debug(" *** unique attributes/values from obj1: ***")
-        difference = debug_set1.difference(debug_set2)
-        for item in debug1:
-            if item in difference:
-                logger.debug(item)
-
-        logger.debug(" -" * 40)
-        logger.debug(" *** unique attributes/values from obj2: ***")
-        difference = debug_set2.difference(debug_set1)
-        for item in debug2:
-            if item in difference:
-                logger.debug(item)
-
-        logger.debug("-" * 79)
-
-
-class BaseCompareVersionAdmin(VersionAdmin):
+class BaseCompareVersionAdmin(CompareMixin, VersionAdmin):
     """
     Enhanced version of VersionAdmin with a flexible compare version API.
 
@@ -501,17 +81,8 @@ class BaseCompareVersionAdmin(VersionAdmin):
     # Template file used for the compare view:
     compare_template = "reversion-compare/compare.html"
 
-    # list/tuple of field names for the compare view. Set to None for all existing fields
-    compare_fields = None
-
-    # list/tuple of field names to exclude from compare view.
-    compare_exclude = None
-
     # change template from django-reversion to add compare selection form:
     object_history_template = "reversion-compare/object_history.html"
-
-    # sort from new to old as default, see: https://github.com/etianen/django-reversion/issues/77
-    history_latest_first = True
 
     def get_urls(self):
         """Returns the additional urls used by the Reversion admin."""
@@ -569,123 +140,6 @@ class BaseCompareVersionAdmin(VersionAdmin):
         }
         context.update(extra_context or {})
         return super(BaseCompareVersionAdmin, self).history_view(request, object_id, context)
-
-    def fallback_compare(self, obj_compare):
-        """
-        Simply create a html diff from the repr() result.
-        Used for every field which has no own compare method.
-        """
-        value1, value2 = obj_compare.to_string()
-        html = html_diff(value1, value2)
-        return html
-
-    def _get_compare(self, obj_compare):
-        """
-        Call the methods to create the compare html part.
-        Try:
-            1. name scheme: "compare_%s" % field_name
-            2. name scheme: "compare_%s" % field.get_internal_type()
-            3. Fallback to: self.fallback_compare()
-        """
-
-        def _get_compare_func(suffix):
-            func_name = "compare_%s" % suffix
-            # logger.debug("func_name: %s", func_name)
-            if hasattr(self, func_name):
-                func = getattr(self, func_name)
-                return func
-
-        # Try method in the name scheme: "compare_%s" % field_name
-        func = _get_compare_func(obj_compare.field_name)
-        if func is not None:
-            html = func(obj_compare)
-            return html
-
-        # Determine if its a reverse field
-        if obj_compare.field in self.reverse_fields:
-            func = _get_compare_func("ManyToOneRel")
-            if func is not None:
-                html = func(obj_compare)
-                return html
-
-        # Try method in the name scheme: "compare_%s" % field.get_internal_type()
-        internal_type = obj_compare.field.get_internal_type()
-        func = _get_compare_func(internal_type)
-        if func is not None:
-            html = func(obj_compare)
-            return html
-
-        # Fallback to self.fallback_compare()
-        html = self.fallback_compare(obj_compare)
-        return html
-
-    def compare(self, obj, version1, version2):
-        """
-        Create a generic html diff from the obj between version1 and version2:
-
-            A diff of every changes field values.
-
-        This method should be overwritten, to create a nice diff view
-        coordinated with the model.
-        """
-        diff = []
-
-        # Create a list of all normal fields and append many-to-many fields
-        fields = [field for field in obj._meta.fields]
-        concrete_model = obj._meta.concrete_model
-        fields += concrete_model._meta.many_to_many
-
-        # This gathers the related reverse ForeignKey fields, so we can do ManyToOne compares
-        self.reverse_fields = []
-        # From: http://stackoverflow.com/questions/19512187/django-list-all-reverse-relations-of-a-model
-        for field_name in obj._meta.get_all_field_names():
-            f = getattr(
-                obj._meta.get_field_by_name(field_name)[0],
-                'field',
-                None
-            )
-            if isinstance(f, models.ForeignKey) and f not in fields:
-                self.reverse_fields.append(f.rel)
-        #print(self.reverse_fields)
-        fields += self.reverse_fields
-
-        has_unfollowed_fields = False
-
-        for field in fields:
-            # logger.debug("%s %s %s", field, field.db_type, field.get_internal_type())
-            try:
-                field_name = field.name
-            except:
-                # is a reverse FK field
-                field_name = field.field_name
-
-            if self.compare_fields and field_name not in self.compare_fields:
-                continue
-            if self.compare_exclude and field_name in self.compare_exclude:
-                continue
-
-            is_reversed = field in self.reverse_fields
-            obj_compare = CompareObjects(field, field_name, obj, version1, version2, self.revision_manager, is_reversed)
-            #obj_compare.debug()
-
-            is_related = obj_compare.is_related
-            follow = obj_compare.follow
-            if is_related and not follow:
-                has_unfollowed_fields = True
-
-            if not obj_compare.changed():
-                # Skip all fields that aren't changed
-                continue
-
-            html = self._get_compare(obj_compare)
-            diff.append({
-                "field": field,
-                "is_related": is_related,
-                "follow": follow,
-                "diff": html,
-            })
-
-        return diff, has_unfollowed_fields
 
     def compare_view(self, request, object_id, extra_context=None):
         """
@@ -759,81 +213,17 @@ class BaseCompareVersionAdmin(VersionAdmin):
                                   context, template.RequestContext(request))
 
 
-class CompareVersionAdmin(BaseCompareVersionAdmin):
+class CompareVersionAdmin(CompareMethodsMixin, BaseCompareVersionAdmin):
     """
-    expand the base class with prepared compare methods.
+    expand the base class with prepared compare methods. This is the
+    class to inherit
     """
-
-    def generic_add_remove(self, raw_value1, raw_value2, value1, value2):
-        if raw_value1 is None:
-            # a new values was added:
-            context = {"value": value2}
-            return render_to_string("reversion-compare/compare_generic_add.html", context)
-        elif raw_value2 is None:
-            # the existing value was removed:
-            context = {"value": value1}
-            return render_to_string("reversion-compare/compare_generic_remove.html", context)
-        else:
-            html = html_diff(value1, value2)
-            return html
-
-    def compare_ForeignKey(self, obj_compare):
-        related1, related2 = obj_compare.get_related()
-        obj_compare.debug()
-        value1, value2 = str(related1), str(related2)
-        # value1, value2 = repr(related1), repr(related2)
-        return self.generic_add_remove(related1, related2, value1, value2)
-
-    def simple_compare_ManyToManyField(self, obj_compare):
-        """ comma separated list of all m2m objects """
-        m2m1, m2m2 = obj_compare.get_many_to_many()
-        old = ", ".join([str(item) for item in m2m1])
-        new = ", ".join([str(item) for item in m2m2])
-        html = html_diff(old, new)
-        return html
-
-    def compare_ManyToOneRel(self, obj_compare):
-        change_info = obj_compare.get_m2o_change_info()
-        context = {"change_info": change_info}
-        return render_to_string("reversion-compare/compare_generic_many_to_many.html", context)
-
-    def compare_ManyToManyField(self, obj_compare):
-        """ create a table for m2m compare """
-        change_info = obj_compare.get_m2m_change_info()
-        context = {"change_info": change_info}
-        return render_to_string("reversion-compare/compare_generic_many_to_many.html", context)
-
-    # compare_ManyToManyField = simple_compare_ManyToManyField
-
-    def compare_FileField(self, obj_compare):
-        value1 = obj_compare.value1
-        value2 = obj_compare.value2
-
-        # FIXME: Needed to not get 'The 'file' attribute has no file associated with it.'
-        if value1:
-            value1 = value1.url
-        else:
-            value1 = None
-
-        if value2:
-            value2 = value2.url
-        else:
-            value2 = None
-
-        return self.generic_add_remove(value1, value2, value1, value2)
-
-    def compare_DateTimeField(self, obj_compare):
-        ''' compare all model datetime model field in ISO format '''
-        context = {
-            "date1": obj_compare.value1,
-            "date2": obj_compare.value2,
-        }
-        return render_to_string("reversion-compare/compare_DateTimeField.html", context)
 
 
 if hasattr(settings, "ADD_REVERSION_ADMIN") and settings.ADD_REVERSION_ADMIN:
     from reversion.models import Revision, Version
 
+    
     class RevisionAdmin(admin.ModelAdmin):
         list_display = ("id", "date_created", "user", "comment")
         list_display_links = ("date_created",)
@@ -844,7 +234,7 @@ if hasattr(settings, "ADD_REVERSION_ADMIN") and settings.ADD_REVERSION_ADMIN:
 
     admin.site.register(Revision, RevisionAdmin)
 
-
+    
     class VersionAdmin(admin.ModelAdmin):
         list_display = ("object_repr", "revision", "object_id", "content_type", "format",)
         list_display_links = ("object_repr", "object_id")

--- a/reversion_compare/compare.py
+++ b/reversion_compare/compare.py
@@ -1,0 +1,434 @@
+"""
+    compare
+    ~~~~~~~
+
+    Compare objects for django-reversion-compare
+
+    :copyleft: 2012-2015 by the django-reversion-compare team, see AUTHORS for more details.
+    :license: GNU GPL v3 or above, see LICENSE for more details.
+"""
+
+from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ObjectDoesNotExist
+from django.db import models
+from django.utils.translation import ugettext as _
+
+import reversion
+from reversion.models import has_int_pk
+
+
+class CompareObject(object):
+    def __init__(self, field, field_name, obj, version, has_int_pk, adapter):
+        self.field = field
+        self.field_name = field_name
+        self.obj = obj
+        self.version = version  # instance of reversion.models.Version()
+        self.has_int_pk = has_int_pk
+        self.adapter = adapter
+        # try and get a value, if none punt
+        self.value = version.field_dict.get(field_name, _("Field Didn't exist!"))
+
+    def _obj_repr(self, obj):
+        # FIXME: How to create a better representation of the current value?
+        try:
+            return str(obj)
+        except Exception as e:
+            return repr(obj)
+
+    def _to_string_ManyToManyField(self):
+        queryset = self.get_many_to_many()
+        return ", ".join([self._obj_repr(item) for item in queryset])
+
+    def _to_string_ForeignKey(self):
+        obj = self.get_related()
+        return self._obj_repr(obj)
+
+    def to_string(self):
+        internal_type = self.field.get_internal_type()
+        func_name = "_to_string_%s" % internal_type
+        if hasattr(self, func_name):
+            func = getattr(self, func_name)
+            return func()
+
+        if isinstance(self.value, str):
+            return self.value
+        else:
+            return self._obj_repr(self.value)
+
+    def __cmp__(self, other):
+        raise NotImplemented()
+
+    def __eq__(self, other):
+        if hasattr(self.field, 'get_internal_type'):
+            assert self.field.get_internal_type() != "ManyToManyField"
+
+        if self.value != other.value:
+            return False
+
+        if not hasattr(self.field, 'get_internal_type') or self.field.get_internal_type() == "ForeignKey":  # FIXME!
+            if self.version.field_dict != other.version.field_dict:
+                return False
+
+        return True
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def get_related(self):
+        if getattr(self.field, 'rel', None):
+            obj = self.version.object_version.object
+            try:
+                return getattr(obj, self.field.name, None)
+            except ObjectDoesNotExist:
+                return None
+
+    def get_reverse_foreign_key(self):
+        obj = self.version.object_version.object
+        if self.has_int_pk and self.field.related_name and hasattr(obj, self.field.related_name):
+            if isinstance(self.field, models.fields.related.OneToOneRel):
+                try:
+                    ids = [getattr(obj, str(self.field.related_name)).pk]
+                except ObjectDoesNotExist:
+                    ids = []
+            else:
+                ids = [v.id for v in getattr(obj, str(self.field.related_name)).all()]  # is: version.field_dict[field.name]
+
+        else:
+            return ([], [], [], [])  # TODO: refactory that
+
+        # Get the related model of the current field:
+        related_model = self.field.field.model
+        return self.get_many_to_something(ids, related_model, is_reverse=True)
+
+    def get_many_to_many(self):
+        """
+        returns a queryset with all many2many objects
+        """
+        if self.field.get_internal_type() != "ManyToManyField":  # FIXME!
+            return ([], [], [], [])  # TODO: refactory that
+        ids = None
+        if self.has_int_pk:
+            ids = [int(v) for v in self.value]  # is: version.field_dict[field.name]
+
+        # Get the related model of the current field:
+        related_model = self.field.rel.to
+        return self.get_many_to_something(ids, related_model)
+
+    def get_many_to_something(self, ids, related_model, is_reverse=False):
+
+        # get instance of reversion.models.Revision():
+        # A group of related object versions.
+        old_revision = self.version.revision
+
+        # Get a queryset with all related objects.
+        versions = old_revision.version_set.filter(
+            content_type=ContentType.objects.get_for_model(related_model),
+            object_id__in=ids
+        )
+
+        if self.has_int_pk:
+            # The primary_keys would be stored in a text field -> convert it to integers
+            # This is interesting in different places!
+            for version in versions:
+                version.object_id = int(version.object_id)
+
+        missing_objects = []
+        missing_ids = []
+
+        if self.field_name not in self.adapter.follow:
+            # This models was not registered with follow relations
+            # Try to fill missing related objects
+            target_ids = set(ids)
+            actual_ids = set([version.object_id for version in versions])
+            missing_ids1 = target_ids.difference(actual_ids)
+
+            # logger.debug(self.field_name, "target: %s - actual: %s - missing: %s" % (target_ids, actual_ids, missing_ids1))
+            if missing_ids1:
+                missing_objects = related_model.objects.all().filter(pk__in=missing_ids1)
+                missing_ids = list(target_ids.difference(set(missing_objects.values_list('pk', flat=True))))
+
+        deleted = []
+        if is_reverse:
+            true_missing_objects = []
+            for o in missing_objects:
+                for ver in reversion.get_for_object(o):
+                    # An object can only be missing if it actually existed prior to this version
+                    # Otherwise its a new item
+                    if ver.revision.date_created < old_revision.date_created:
+                        true_missing_objects.append(o)
+            missing_objects = true_missing_objects
+            deleted = [d for d in reversion.get_deleted(related_model) if d.revision == old_revision]
+        return versions, missing_objects, missing_ids, deleted
+
+    def get_debug(self):
+        if not settings.DEBUG:
+            return
+
+        result = [
+            "field..............: %r" % self.field,
+            "field_name.........: %r" % self.field_name,
+            "field internal type: %r" % self.field.get_internal_type(),
+            "field_dict.........: %s" % repr(self.version.field_dict),
+            "adapter............: %r (follow: %r)" % (self.adapter, ", ".join(self.adapter.follow)),
+            "has_int_pk ........: %r" % self.has_int_pk,
+            "obj................: %r (pk: %s, id: %s)" % (self.obj, self.obj.pk, id(self.obj)),
+            "version............: %r (pk: %s, id: %s)" % (self.version, self.version.pk, id(self.version)),
+            "value..............: %r" % self.value,
+            "to string..........: %s" % repr(self.to_string()),
+            "related............: %s" % repr(self.get_related()),
+        ]
+        m2m_versions, missing_objects, missing_ids, deleted = self.get_many_to_many()
+        if m2m_versions or missing_objects or missing_ids:
+            result.append(
+                "many-to-many.......: %s" % ", ".join(
+                    ["%s (%s)" % (
+                        item,
+                        item.type
+                    ) for item in m2m_versions]
+                )
+            )
+
+            if missing_objects:
+                result.append("missing m2m objects: %s" % repr(missing_objects))
+            else:
+                result.append("missing m2m objects: (has no)")
+
+            if missing_ids:
+                result.append("missing m2m IDs....: %s" % repr(missing_ids))
+            else:
+                result.append("missing m2m IDs....: (has no)")
+        else:
+            result.append("many-to-many.......: (has no)")
+
+        return result
+
+    def debug(self):
+        if not settings.DEBUG:
+            return
+        for item in self.get_debug():
+            logger.debug(item)
+
+
+class CompareObjects(object):
+    def __init__(self, field, field_name, obj, version1, version2, manager, is_reversed):
+        self.field = field
+        self.field_name = field_name
+        self.obj = obj
+
+        model = self.obj.__class__
+        self.has_int_pk = has_int_pk(model)
+        self.adapter = manager.get_adapter(model)  # VersionAdapter instance
+
+        # is a related field (ForeignKey, ManyToManyField etc.)
+        self.is_related = getattr(self.field, 'rel', None) is not None
+        self.is_reversed = is_reversed
+        if not self.is_related:
+            self.follow = None
+        elif self.field_name in self.adapter.follow:
+            self.follow = True
+        else:
+            self.follow = False
+
+        self.compare_obj1 = CompareObject(field, field_name, obj, version1, self.has_int_pk, self.adapter)
+        self.compare_obj2 = CompareObject(field, field_name, obj, version2, self.has_int_pk, self.adapter)
+
+        self.value1 = self.compare_obj1.value
+        self.value2 = self.compare_obj2.value
+
+    def changed(self):
+        """ return True if at least one field has changed values. """
+
+        info = None
+        if hasattr(self.field, 'get_internal_type') and self.field.get_internal_type() == "ManyToManyField":
+            info = self.get_m2m_change_info()
+        elif self.is_reversed:
+            info = self.get_m2o_change_info()
+        if info:
+            keys = (
+                "changed_items", "removed_items", "added_items",
+                "removed_missing_objects", "added_missing_objects", 'deleted_items'
+            )
+            for key in keys:
+                if info[key]:
+                    return True
+            return False
+
+        return self.compare_obj1 != self.compare_obj2
+
+    def _get_result(self, compare_obj, func_name):
+        func = getattr(compare_obj, func_name)
+        result = func()
+        return result
+
+    def _get_both_results(self, func_name):
+        result1 = self._get_result(self.compare_obj1, func_name)
+        result2 = self._get_result(self.compare_obj2, func_name)
+        return (result1, result2)
+
+    def to_string(self):
+        return self._get_both_results("to_string")
+
+    def get_related(self):
+        return self._get_both_results("get_related")
+
+    def get_many_to_many(self):
+        # return self._get_both_results("get_many_to_many")
+        m2m_data1, m2m_data2 = self._get_both_results("get_many_to_many")
+        return m2m_data1, m2m_data2
+
+    def get_reverse_foreign_key(self):
+        return self._get_both_results("get_reverse_foreign_key")
+
+    M2O_CHANGE_INFO = None
+
+    def get_m2o_change_info(self):
+        if self.M2O_CHANGE_INFO is not None:
+            return self.M2O_CHANGE_INFO
+
+        m2o_data1, m2o_data2 = self.get_reverse_foreign_key()
+
+        self.M2O_CHANGE_INFO = self.get_m2s_change_info(m2o_data1, m2o_data2)
+        return self.M2O_CHANGE_INFO
+
+    M2M_CHANGE_INFO = None
+
+    def get_m2m_change_info(self):
+        if self.M2M_CHANGE_INFO is not None:
+            return self.M2M_CHANGE_INFO
+
+        m2m_data1, m2m_data2 = self.get_many_to_many()
+
+        self.M2M_CHANGE_INFO = self.get_m2s_change_info(m2m_data1, m2m_data2)
+        return self.M2M_CHANGE_INFO
+
+    # Abstract Many-to-Something (either -many or -one) as both
+    # many2many and many2one relationships looks the same from the refered object.
+    def get_m2s_change_info(self, obj1_data, obj2_data):
+
+        result1, missing_objects1, missing_ids1, deleted1 = obj1_data
+        result2, missing_objects2, missing_ids2, deleted2 = obj2_data
+
+        # missing_objects_pk1 = [obj.pk for obj in missing_objects1]
+        #        missing_objects_pk2 = [obj.pk for obj in missing_objects2]
+        missing_objects_dict2 = dict([(obj.pk, obj) for obj in missing_objects2])
+
+        # logger.debug("missing_objects1: %s", missing_objects1)
+        # logger.debug("missing_objects2: %s", missing_objects2)
+        # logger.debug("missing_ids1: %s", missing_ids1)
+        # logger.debug("missing_ids2: %s", missing_ids2)
+
+        missing_object_set1 = set(missing_objects1)
+        missing_object_set2 = set(missing_objects2)
+        # logger.debug("%s %s", missing_object_set1, missing_object_set2)
+
+        same_missing_objects = missing_object_set1.intersection(missing_object_set2)
+        removed_missing_objects = missing_object_set1.difference(missing_object_set2)
+        added_missing_objects = missing_object_set2.difference(missing_object_set1)
+
+        # logger.debug("same_missing_objects: %s", same_missing_objects)
+        # logger.debug("removed_missing_objects: %s", removed_missing_objects)
+        # logger.debug("added_missing_objects: %s", added_missing_objects)
+
+
+        # Create same_items, removed_items, added_items with related m2m items
+
+        changed_items = []
+        removed_items = []
+        added_items = []
+        same_items = []
+
+        primary_keys1 = [version.object_id for version in result1]
+        primary_keys2 = [version.object_id for version in result2]
+
+        result_dict1 = dict([(version.object_id, version) for version in result1])
+        result_dict2 = dict([(version.object_id, version) for version in result2])
+
+        # logger.debug(result_dict1)
+        # logger.debug(result_dict2)
+
+        for primary_key in set(primary_keys1).union(set(primary_keys2)):
+            if primary_key in result_dict1:
+                version1 = result_dict1[primary_key]
+            else:
+                version1 = None
+
+            if primary_key in result_dict2:
+                version2 = result_dict2[primary_key]
+            else:
+                version2 = None
+
+            #logger.debug("%r - %r - %r", primary_key, version1, version2)
+
+            if version1 is not None and version2 is not None:
+                # In both -> version changed or the same
+                if version1.serialized_data == version2.serialized_data:
+                    #logger.debug("same item: %s", version1)
+                    same_items.append(version1)
+                else:
+                    changed_items.append((version1, version2))
+            elif version1 is not None and version2 is None:
+                # In 1 but not in 2 -> removed
+                #logger.debug("%s %s", primary_key, missing_objects_pk2)
+                #logger.debug("%s %s", repr(primary_key), repr(missing_objects_pk2))
+                if primary_key in missing_objects_dict2:
+                    missing_object = missing_objects_dict2[primary_key]
+                    added_missing_objects.remove(missing_object)
+                    same_missing_objects.add(missing_object)
+                    continue
+
+                removed_items.append(version1)
+            elif version1 is None and version2 is not None:
+                # In 2 but not in 1 -> added
+                #logger.debug("added: %s", version2)
+                added_items.append(version2)
+            else:
+                raise RuntimeError()
+
+        return {
+            "changed_items": changed_items,
+            "removed_items": removed_items,
+            "added_items": added_items,
+            "same_items": same_items,
+            "same_missing_objects": same_missing_objects,
+            "removed_missing_objects": removed_missing_objects,
+            "added_missing_objects": added_missing_objects,
+            "deleted_items": deleted1,
+        }
+
+
+    def debug(self):
+        if not settings.DEBUG:
+            return
+        logger.debug("_______________________________")
+        logger.debug(" *** CompareObjects debug: ***")
+        logger.debug("changed: %s", self.changed())
+        logger.debug("follow: %s", self.follow)
+
+        debug1 = self.compare_obj1.get_debug()
+        debug2 = self.compare_obj2.get_debug()
+        debug_set1 = set(debug1)
+        debug_set2 = set(debug2)
+
+        logger.debug(" *** same attributes/values in obj1 and obj2: ***")
+        intersection = debug_set1.intersection(debug_set2)
+        for item in debug1:
+            if item in intersection:
+                logger.debug(item)
+
+        logger.debug(" -" * 40)
+        logger.debug(" *** unique attributes/values from obj1: ***")
+        difference = debug_set1.difference(debug_set2)
+        for item in debug1:
+            if item in difference:
+                logger.debug(item)
+
+        logger.debug(" -" * 40)
+        logger.debug(" *** unique attributes/values from obj2: ***")
+        difference = debug_set2.difference(debug_set1)
+        for item in debug2:
+            if item in difference:
+                logger.debug(item)
+
+        logger.debug("-" * 79)
+

--- a/reversion_compare/mixins.py
+++ b/reversion_compare/mixins.py
@@ -14,7 +14,7 @@ from django.template.loader import render_to_string
 from reversion_compare.helpers import html_diff
 from reversion.revisions import default_revision_manager
 
-from compare import CompareObjects
+from reversion_compare.compare import CompareObjects
 
 class CompareMixin(object, ):
     """A mixin to add comparison capabilities to your views"""

--- a/reversion_compare/mixins.py
+++ b/reversion_compare/mixins.py
@@ -1,0 +1,224 @@
+"""
+    mixin
+    ~~~~~
+
+    Mixins for views (admin and cbv) for django-reversion-compare
+
+    :copyleft: 2012-2015 by the django-reversion-compare team, see AUTHORS for more details.
+    :license: GNU GPL v3 or above, see LICENSE for more details.
+"""
+
+from django.db import models
+from django.template.loader import render_to_string
+
+from reversion_compare.helpers import html_diff
+from reversion.revisions import default_revision_manager
+
+from compare import CompareObjects
+
+class CompareMixin(object, ):
+    """A mixin to add comparison capabilities to your views"""
+    
+    revision_manager = default_revision_manager
+    # list/tuple of field names for the compare view. Set to None for all existing fields
+    compare_fields = None
+
+    # list/tuple of field names to exclude from compare view.
+    compare_exclude = None
+
+    # sort from new to old as default, see: https://github.com/etianen/django-reversion/issues/77
+    history_latest_first = True
+    
+    def _order_version_queryset(self, queryset):
+        """Applies the correct ordering to the given version queryset."""
+        if self.history_latest_first:
+            return queryset.order_by("-pk")
+        return queryset.order_by("pk")
+
+    def _get_compare(self, obj_compare):
+        """
+        Call the methods to create the compare html part.
+        Try:
+            1. name scheme: "compare_%s" % field_name
+            2. name scheme: "compare_%s" % field.get_internal_type()
+            3. Fallback to: self.fallback_compare()
+        """
+
+        def _get_compare_func(suffix):
+            func_name = "compare_%s" % suffix
+            # logger.debug("func_name: %s", func_name)
+            if hasattr(self, func_name):
+                func = getattr(self, func_name)
+                return func
+
+        # Try method in the name scheme: "compare_%s" % field_name
+        func = _get_compare_func(obj_compare.field_name)
+        if func is not None:
+            html = func(obj_compare)
+            return html
+
+        # Determine if its a reverse field
+        if obj_compare.field in self.reverse_fields:
+            func = _get_compare_func("ManyToOneRel")
+            if func is not None:
+                html = func(obj_compare)
+                return html
+
+        # Try method in the name scheme: "compare_%s" % field.get_internal_type()
+        internal_type = obj_compare.field.get_internal_type()
+        func = _get_compare_func(internal_type)
+        if func is not None:
+            html = func(obj_compare)
+            return html
+
+        # Fallback to self.fallback_compare()
+        html = self.fallback_compare(obj_compare)
+        return html
+
+    def compare(self, obj, version1, version2):
+        """
+        Create a generic html diff from the obj between version1 and version2:
+
+            A diff of every changes field values.
+
+        This method should be overwritten, to create a nice diff view
+        coordinated with the model.
+        """
+        diff = []
+
+        # Create a list of all normal fields and append many-to-many fields
+        fields = [field for field in obj._meta.fields]
+        concrete_model = obj._meta.concrete_model
+        fields += concrete_model._meta.many_to_many
+
+        # This gathers the related reverse ForeignKey fields, so we can do ManyToOne compares
+        self.reverse_fields = []
+        # From: http://stackoverflow.com/questions/19512187/django-list-all-reverse-relations-of-a-model
+        for field_name in obj._meta.get_all_field_names():
+            f = getattr(
+                obj._meta.get_field_by_name(field_name)[0],
+                'field',
+                None
+            )
+            if isinstance(f, models.ForeignKey) and f not in fields:
+                self.reverse_fields.append(f.rel)
+        #print(self.reverse_fields)
+        fields += self.reverse_fields
+
+        has_unfollowed_fields = False
+
+        for field in fields:
+            # logger.debug("%s %s %s", field, field.db_type, field.get_internal_type())
+            try:
+                field_name = field.name
+            except:
+                # is a reverse FK field
+                field_name = field.field_name
+
+            if self.compare_fields and field_name not in self.compare_fields:
+                continue
+            if self.compare_exclude and field_name in self.compare_exclude:
+                continue
+
+            is_reversed = field in self.reverse_fields
+            obj_compare = CompareObjects(field, field_name, obj, version1, version2, self.revision_manager, is_reversed)
+            #obj_compare.debug()
+
+            is_related = obj_compare.is_related
+            follow = obj_compare.follow
+            if is_related and not follow:
+                has_unfollowed_fields = True
+
+            if not obj_compare.changed():
+                # Skip all fields that aren't changed
+                continue
+
+            html = self._get_compare(obj_compare)
+            diff.append({
+                "field": field,
+                "is_related": is_related,
+                "follow": follow,
+                "diff": html,
+            })
+
+        return diff, has_unfollowed_fields
+
+    def fallback_compare(self, obj_compare):
+        """
+        Simply create a html diff from the repr() result.
+        Used for every field which has no own compare method.
+        """
+        value1, value2 = obj_compare.to_string()
+        html = html_diff(value1, value2)
+        return html
+
+
+class CompareMethodsMixin(object,):
+    """A mixin to add prepared compare methods."""
+    
+    def generic_add_remove(self, raw_value1, raw_value2, value1, value2):
+        if raw_value1 is None:
+            # a new values was added:
+            context = {"value": value2}
+            return render_to_string("reversion-compare/compare_generic_add.html", context)
+        elif raw_value2 is None:
+            # the existing value was removed:
+            context = {"value": value1}
+            return render_to_string("reversion-compare/compare_generic_remove.html", context)
+        else:
+            html = html_diff(value1, value2)
+            return html
+
+    def compare_ForeignKey(self, obj_compare):
+        related1, related2 = obj_compare.get_related()
+        obj_compare.debug()
+        value1, value2 = str(related1), str(related2)
+        # value1, value2 = repr(related1), repr(related2)
+        return self.generic_add_remove(related1, related2, value1, value2)
+
+    def simple_compare_ManyToManyField(self, obj_compare):
+        """ comma separated list of all m2m objects """
+        m2m1, m2m2 = obj_compare.get_many_to_many()
+        old = ", ".join([str(item) for item in m2m1])
+        new = ", ".join([str(item) for item in m2m2])
+        html = html_diff(old, new)
+        return html
+
+    def compare_ManyToOneRel(self, obj_compare):
+        change_info = obj_compare.get_m2o_change_info()
+        context = {"change_info": change_info}
+        return render_to_string("reversion-compare/compare_generic_many_to_many.html", context)
+
+    def compare_ManyToManyField(self, obj_compare):
+        """ create a table for m2m compare """
+        change_info = obj_compare.get_m2m_change_info()
+        context = {"change_info": change_info}
+        return render_to_string("reversion-compare/compare_generic_many_to_many.html", context)
+
+    # compare_ManyToManyField = simple_compare_ManyToManyField
+
+    def compare_FileField(self, obj_compare):
+        value1 = obj_compare.value1
+        value2 = obj_compare.value2
+
+        # FIXME: Needed to not get 'The 'file' attribute has no file associated with it.'
+        if value1:
+            value1 = value1.url
+        else:
+            value1 = None
+
+        if value2:
+            value2 = value2.url
+        else:
+            value2 = None
+
+        return self.generic_add_remove(value1, value2, value1, value2)
+
+    def compare_DateTimeField(self, obj_compare):
+        ''' compare all model datetime model field in ISO format '''
+        context = {
+            "date1": obj_compare.value1,
+            "date2": obj_compare.value2,
+        }
+        return render_to_string("reversion-compare/compare_DateTimeField.html", context)
+        

--- a/reversion_compare/templates/reversion-compare/action_list_partial.html
+++ b/reversion_compare/templates/reversion-compare/action_list_partial.html
@@ -1,0 +1,51 @@
+{% load i18n l10n %}
+{% if compare_view %}<form method="GET" action="{{ action }}">{% endif %}
+<table id="change-history">
+    <thead>
+        <tr>
+            {% if compare_view %}
+                <th scope="col">
+                    {% if comparable %}
+                        <input type="submit" value="{% trans 'compare' %}">
+                    {% else %}
+                       <i>{% trans 'compare' %}</i>
+                    {% endif %}
+                </th>
+            {% endif %}
+            <th scope="col">{% trans 'Date/time' %}</th>
+            <th scope="col">{% trans 'User' %}</th>
+            <th scope="col">{% trans 'Comment' %}</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for action in action_list %}
+            <tr>
+                {% if compare_view %}
+                <td scope="row">
+                    {% if comparable %}
+                       <input type="radio" name="version_id1" value="{{ action.version.pk|unlocalize }}" {% if action.first %}style="visibility:hidden" {% endif %}{% if version1.pk|unlocalize == action.version.pk|unlocalize or action.second %}checked="checked"{% endif%}/>
+                       <input type="radio" name="version_id2" value="{{ action.version.pk|unlocalize }}" {% if version2.pk|unlocalize == action.version.pk|unlocalize or action.first == 1 %}checked="checked"{% endif%}/>
+                    {% else %}
+                       <i>-</i>
+                    {% endif %}
+                </td>
+                {% endif %}
+                <th scope="row">
+                    {% if action.url %}
+                        <a href="{{action.url}}">{{action.revision.date_created|date:_("DATETIME_FORMAT")}}</a>
+                    {% else %}
+                        {{action.revision.date_created|date:_("DATETIME_FORMAT")}}
+                    {% endif %}
+                </th>
+                <td>
+                    {% if action.revision.user %}
+                        {{action.revision.user.username}}
+                        {% if action.revision.user.first_name %} ({{action.revision.user.first_name}} {{action.revision.user.last_name}}){% endif %}
+                    {% endif %}
+                </td>
+                <td>{{action.revision.comment|default:""}}</td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% if compare_view %}</form>{% endif %}

--- a/reversion_compare/templates/reversion-compare/compare.html
+++ b/reversion_compare/templates/reversion-compare/compare.html
@@ -32,8 +32,7 @@
         {% block object-tools %}
             <ul class="object-tools">
               {% block object-tools-items %}
-                {% if prev_url %}<li><a href="{{ prev_url }}">&lsaquo; {% trans "previous" %}</a></li>{% endif %}
-                {% if next_url %}<li><a href="{{ next_url }}">{% trans "next" %} &rsaquo;</a></li>{% endif %}
+                {% include "reversion-compare/compare_links_partial.html"  %}
               {% endblock %}
             </ul>
         {% endblock %}
@@ -44,30 +43,8 @@
             {% endblocktrans %}
         </p>
         &lsaquo; <a href="{{history_url}}">{% trans "Go back to history list" %}</a>
-        {% for field_diff in compare_data %}
-            <h3>{% firstof field_diff.field.verbose_name field_diff.field.related_name %}{% if field_diff.is_related and not field_diff.follow %}<sup class="follow">*</sup>{% endif %}</h3>
-            {% if field_diff.field.help_text %}<p class="help">{{ field_diff.field.help_text }}</p>{% endif %}
-            <div class="module">
-                <p>{{ field_diff.diff }}</p>
-            </div>
-        {% empty %}
-            <div class="module">
-                <p><strong>{% trans "There are no differences." %}</strong></p>
-            </div>
-        {% endfor %}
-
-        <h4>{% trans "Edit comment:" %}</h4>
-        <blockquote>{{ version2.revision.comment|default:"(there exist not comment)" }}</blockquote>
-
-        {% if has_unfollowed_fields %}
-        <h4 class="follow">{% trans "Note:" %}</h4>
-        <p class="follow">
-            {% blocktrans %}
-                Fields/entries marked with <sup class="follow">*</sup> are not under reversion control.
-                It may be that not all marked information are correct.
-            {% endblocktrans %}
-        </p>
-        {% endif %}
+        
+        {% include "reversion-compare/compare_partial.html"  %}
 
         &lsaquo; <a href="{{history_url}}">{% trans "Go back to history list" %}</a>
     </div>

--- a/reversion_compare/templates/reversion-compare/compare_links_partial.html
+++ b/reversion_compare/templates/reversion-compare/compare_links_partial.html
@@ -1,0 +1,3 @@
+{% load i18n %}
+{% if prev_url %}<li><a href="{{ prev_url }}">&lsaquo; {% trans "previous" %}</a></li>{% endif %}
+{% if next_url %}<li><a href="{{ next_url }}">{% trans "next" %} &rsaquo;</a></li>{% endif %}

--- a/reversion_compare/templates/reversion-compare/compare_partial.html
+++ b/reversion_compare/templates/reversion-compare/compare_partial.html
@@ -1,0 +1,25 @@
+{% load i18n %}
+{% for field_diff in compare_data %}
+    <h3>{% firstof field_diff.field.verbose_name field_diff.field.related_name %}{% if field_diff.is_related and not field_diff.follow %}<sup class="follow">*</sup>{% endif %}</h3>
+    {% if field_diff.field.help_text %}<p class="help">{{ field_diff.field.help_text }}</p>{% endif %}
+    <div class="module">
+        <p>{{ field_diff.diff }}</p>
+    </div>
+{% empty %}
+    <div class="module">
+        <p><strong>{% trans "There are no differences." %}</strong></p>
+    </div>
+{% endfor %}
+
+<h4>{% trans "Edit comment:" %}</h4>
+<blockquote>{{ version2.revision.comment|default:"(no comment exists)" }}</blockquote>
+
+{% if has_unfollowed_fields %}
+<h4 class="follow">{% trans "Note:" %}</h4>
+<p class="follow">
+    {% blocktrans %}
+        Fields/entries marked with <sup class="follow">*</sup> are not under reversion control.
+        It may be that not all marked information are correct.
+    {% endblocktrans %}
+</p>
+{% endif %}

--- a/reversion_compare/templates/reversion-compare/object_history.html
+++ b/reversion_compare/templates/reversion-compare/object_history.html
@@ -8,50 +8,7 @@
     
         <div class="module">
             {% if action_list %}
-                {% if compare_view %}<form method="GET" action="../history/compare/">{% endif %}
-                <table id="change-history">
-                    <thead>
-                        <tr>
-                            {% if compare_view %}
-                                <th scope="col">
-                                    {% if comparable %}
-                                        <input type="submit" value="{% trans 'compare' %}">
-                                    {% else %}
-                                       <i>{% trans 'compare' %}</i>
-                                    {% endif %}
-                                </th>
-                            {% endif %}
-                            <th scope="col">{% trans 'Date/time' %}</th>
-                            <th scope="col">{% trans 'User' %}</th>
-                            <th scope="col">{% trans 'Comment' %}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for action in action_list %}
-                            <tr>
-                                {% if compare_view %}
-                                <td scope="row">
-                                    {% if comparable %}
-                                       <input type="radio" name="version_id1" value="{{ action.version.pk|unlocalize }}" {% if action.first %}style="visibility:hidden" {% endif %}{% if action.second %}checked="checked" {% endif %}/>
-                                       <input type="radio" name="version_id2" value="{{ action.version.pk|unlocalize }}" {% if action.first == 1 %}checked="checked" {% endif %}/>
-                                    {% else %}
-                                       <i>-</i>
-                                    {% endif %}
-                                </td>
-                                {% endif %}
-                                <th scope="row"><a href="{{action.url}}">{{action.revision.date_created|date:_("DATETIME_FORMAT")}}</a></th>
-                                <td>
-                                    {% if action.revision.user %}
-                                        {{action.revision.user.username}}
-                                        {% if action.revision.user.first_name %} ({{action.revision.user.first_name}} {{action.revision.user.last_name}}){% endif %}
-                                    {% endif %}
-                                </td>
-                                <td>{{action.revision.comment|default:""}}</td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-                {% if compare_view %}</form>{% endif %}
+                {% include "reversion-compare/action_list_partial.html" with action="../history/compare/" %}
             {% else %}
                 <p>{% trans "This object doesn't have a change history. It probably wasn't added via this admin site." %}</p>
             {% endif %}

--- a/reversion_compare/views.py
+++ b/reversion_compare/views.py
@@ -1,0 +1,130 @@
+from django.http import Http404
+from django.shortcuts import get_object_or_404
+from django.views.generic.detail import DetailView
+
+from reversion_compare.forms import SelectDiffForm
+from reversion_compare.mixins import CompareMixin, CompareMethodsMixin
+
+class HistoryCompareDetailView(CompareMixin, CompareMethodsMixin, DetailView):
+    """This class can be used to add a non-admin view for comparing your object's versions.
+    
+    You can use it just like a normal DetailView:
+    
+    Inherit from it in your class and add a model (or queryset), for example:
+    
+    class SimpleModelHistoryCompareView(HistoryCompareDetailView):
+        model = SimpleModel
+        
+    and assign that CBV to a url: 
+    
+    url(r'^test_view/(?P<pk>\d+)$', views.SimpleModelHistoryCompareView.as_view() ),
+    
+    Last step, you need to create a template to display both the version select form and 
+    the changes part (if the form is submitted). An example template is the following:
+    
+    <style type="text/css">
+    /* minimal style for the diffs */
+    del, ins {
+        color: #000;
+        text-decoration: none;
+    }
+    del { background-color: #ffe6e6; }
+    ins { background-color: #e6ffe6; }
+    sup.follow { color: #5555ff; }
+    </style>
+
+
+    {% include "reversion-compare/action_list_partial.html"  %}
+    {% include "reversion-compare/compare_partial.html"  %}
+    {% include "reversion-compare/compare_links_partial.html"  %}
+
+    
+    Beyond the styling, you should include 
+    - reversion-compare/action_list_partial.html partial template to display the version select form
+    - reversion-compare/compare_partial.html partial template to display the actual version
+    - reversion-compare/compare_links_partial.html to include previous/next comparison links
+    
+    If you want more control on the appearence of your templates you can check these partials
+    to understand how the availabble context variables are used.
+    """
+    
+    def _get_action_list(self, ):
+        opts = self.model._meta
+        action_list = [
+            {
+                "version": version,
+                "revision": version.revision,
+            }
+            for version
+            in self._order_version_queryset(self.revision_manager.get_for_object(
+                self.get_object(),
+            ).select_related("revision__user"))
+        ]
+        return action_list
+
+    def get_context_data(self, **kwargs):
+        context = super(HistoryCompareDetailView, self).get_context_data()
+        action_list = self._get_action_list()
+
+        if len(action_list) < 2:
+            # Less than two history items aren't enough to compare ;)
+            comparable = False
+        else:
+            comparable = True
+            # for pre selecting the compare radio buttons depend on the ordering:
+            if self.history_latest_first:
+                action_list[0]["first"] = True
+                action_list[1]["second"] = True
+            else:
+                action_list[-1]["first"] = True
+                action_list[-2]["second"] = True
+            
+        if self.request.GET: 
+            form = SelectDiffForm(self.request.GET)
+            if not form.is_valid():
+                msg = "Wrong version IDs."
+                raise Http404(msg)
+
+            version_id1 = form.cleaned_data["version_id1"]
+            version_id2 = form.cleaned_data["version_id2"]
+
+            if version_id1 > version_id2:
+                # Compare always the newest one (#2) with the older one (#1)
+                version_id1, version_id2 = version_id2, version_id1
+
+            obj = self.get_object()
+            queryset = self.revision_manager.get_for_object(obj)
+            version1 = get_object_or_404(queryset, pk=version_id1)
+            version2 = get_object_or_404(queryset, pk=version_id2)
+
+            next_version = queryset.filter(pk__gt=version_id2).last()
+            prev_version = queryset.filter(pk__lt=version_id1).first()
+
+            compare_data, has_unfollowed_fields = self.compare(obj, version1, version2)
+            
+            context.update({
+                "compare_data": compare_data,
+                "has_unfollowed_fields": has_unfollowed_fields,
+                "version1": version1,
+                "version2": version2,
+            })
+            
+            if next_version:
+                next_url = "?version_id1=%i&version_id2=%i" % (
+                    version2.id, next_version.id
+                )
+                context.update({'next_url': next_url})
+            if prev_version:
+                prev_url = "?version_id1=%i&version_id2=%i" % (
+                    prev_version.id, version1.id
+                )
+                context.update({'prev_url': prev_url})
+
+
+        # Compile the context.
+        context.update({
+            "action_list": action_list,
+            "comparable": comparable,
+            "compare_view": True,
+        })
+        return context

--- a/tests/templates/tests/simplemodel_detail.html
+++ b/tests/templates/tests/simplemodel_detail.html
@@ -1,0 +1,17 @@
+
+<style type="text/css">
+    /* minimal style for the diffs */
+    del, ins {
+        color: #000;
+        text-decoration: none;
+    }
+    del { background-color: #ffe6e6; }
+    ins { background-color: #e6ffe6; }
+    sup.follow { color: #5555ff; }
+</style>
+
+
+{% include "reversion-compare/action_list_partial.html"  %}
+{% include "reversion-compare/compare_partial.html"  %}
+{% include "reversion-compare/compare_links_partial.html"  %}
+

--- a/tests/test_variant_model.py
+++ b/tests/test_variant_model.py
@@ -16,6 +16,7 @@
 """
 
 from __future__ import absolute_import, division, print_function
+import os
 from django.conf import settings
 
 
@@ -189,8 +190,10 @@ class VariantModelWithDataTest(BaseTestCase):
             "<ins>+ https://github.com/jedie/</ins>",
 
             "<h3>filepath</h3>",
-            "<del>- %s/foo</del>" % settings.UNITTEST_TEMP_PATH,
-            "<ins>+ %s/bar</ins>" % settings.UNITTEST_TEMP_PATH,
+            #"<del>- %s/foo</del>" % settings.UNITTEST_TEMP_PATH,
+            #"<ins>+ %s/bar</ins>" % settings.UNITTEST_TEMP_PATH,
+            "<del>- %s</del>" % os.path.join(settings.UNITTEST_TEMP_PATH, 'foo'),
+            "<ins>+ %s</ins>" % os.path.join(settings.UNITTEST_TEMP_PATH, 'bar'),
 
             "<h3>ip address</h3>",
             "<del>- 192.168.0.1</del>",

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+"""
+    django-reversion-compare unittests
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Test history compare CBV
+    
+    :copyleft: 2012-2015 by the django-reversion-compare team, see AUTHORS for more details.
+    :license: GNU GPL v3 or above, see LICENSE for more details.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import datetime
+
+from django.core.urlresolvers import reverse
+from django.db.models.loading import get_models, get_app
+from django.test import TestCase
+from django.contrib.auth.models import User
+
+
+
+try:
+    import django_tools
+except ImportError as err:
+    msg = (
+        "Please install django-tools for unittests"
+        " - https://github.com/jedie/django-tools/"
+        " - Original error: %s"
+    ) % err
+    raise ImportError(msg)
+from django_tools.unittest_utils.BrowserDebug import debug_response
+
+import reversion
+from reversion import get_for_object
+from reversion.models import Revision, Version
+
+from reversion_compare import helpers
+
+from .test_utils.test_cases import BaseTestCase
+from .models import SimpleModel
+from .test_utils.test_data import TestData
+
+
+class CBViewTest(BaseTestCase):
+    """
+    unittests for testing reversion_compare.views.HistoryCompareDetailView
+
+    Tests for the basic functions.
+    """
+    def setUp(self):
+        super(CBViewTest, self).setUp()
+        test_data = TestData(verbose=False)
+        self.item1, self.item2 = test_data.create_Simple_data()
+
+        queryset = get_for_object(self.item1)
+        self.version_ids1 = queryset.values_list("pk", flat=True)
+        
+        queryset = get_for_object(self.item2)
+        self.version_ids2 = queryset.values_list("pk", flat=True)
+
+    def test_initial_state(self):
+        self.assertTrue(reversion.is_registered(SimpleModel))
+
+        self.assertEqual(SimpleModel.objects.count(), 2)
+        self.assertEqual(SimpleModel.objects.all()[0].text, "version two")
+
+        self.assertEqual(reversion.get_for_object(self.item1).count(), 2)
+        self.assertEqual(list(self.version_ids1), [2, 1])
+        
+        self.assertEqual(list(self.version_ids1), [2, 1])
+        self.assertEqual(list(self.version_ids2), [7, 6, 5, 4, 3])
+        
+    def test_select_compare1(self):
+        response = self.client.get("/test_view/%s" % self.item1.pk)
+        self.assertContainsHtml(response,
+            '<input type="submit" value="compare">',
+            '<input type="radio" name="version_id1" value="%i" style="visibility:hidden" />' % self.version_ids1[0],
+            '<input type="radio" name="version_id2" value="%i" checked="checked" />' % self.version_ids1[0],
+            '<input type="radio" name="version_id1" value="%i" checked="checked" />' % self.version_ids1[1],
+            '<input type="radio" name="version_id2" value="%i" />' % self.version_ids1[1],
+        )
+        
+    def test_select_compare2(self):
+        response = self.client.get("/test_view/%s" % self.item2.pk)
+        # debug_response(response) # from django-tools
+        for i in range(4):
+            if i==0:
+                comment = "create v%i" % i
+            else:
+                comment = "change to v%i" % i
+
+            self.assertContainsHtml(response,
+                "<td>%s</td>" % comment,
+                '<input type="submit" value="compare">',
+            )
+        
+    def test_select_compare_and_diff(self):
+        response = self.client.get("/test_view/%s" % self.item1.pk, data={"version_id2":self.version_ids1[0], "version_id1":self.version_ids1[1]})
+        self.assertContainsHtml(response,
+            '<input type="submit" value="compare">',
+            '<input type="radio" name="version_id1" value="%i" style="visibility:hidden" />' % self.version_ids1[0],
+            '<input type="radio" name="version_id2" value="%i" checked="checked" />' % self.version_ids1[0],
+            '<input type="radio" name="version_id1" value="%i" checked="checked" />' % self.version_ids1[1],
+            '<input type="radio" name="version_id2" value="%i" />' % self.version_ids1[1],
+        )
+        self.assertContainsHtml(response,
+            '<del>- version one</del>',
+            '<ins>+ version two</ins>',
+            '<blockquote>simply change the CharField text.</blockquote>', # edit comment
+        )
+        
+    def test_prev_next_buttons(self):
+        base_url="/test_view/%s" % self.item2.pk
+        for i in range(4):
+            # IDs: 3,4,5,6
+            id1=i+3
+            id2=i+4
+            response = self.client.get(base_url,
+                data={"version_id2":id2, "version_id1":id1}
+            )
+            self.assertContainsHtml(response,
+                '<del>- v%i</del>' % i,
+                '<ins>+ v%i</ins>' % (i+1),
+                '<blockquote>change to v%i</blockquote>' % (i+1),
+            )
+
+            next = '<a href="?version_id1=%s&amp;version_id2=%s">next &rsaquo;</a>' % (i+4, i+5)
+            prev = '<a href="?version_id1=%s&amp;version_id2=%s">&lsaquo; previous</a>' % (i+2,i+3)
+
+            if i==0:
+                self.assertNotContains(response, "previous")
+                self.assertContains(response, "next")
+                self.assertContainsHtml(response, next)
+            elif i==3:
+                self.assertContains(response, "previous")
+                self.assertNotContains(response, "next")
+                self.assertContainsHtml(response, prev)
+            else:
+                self.assertContains(response, "previous")
+                self.assertContains(response, "next")
+                self.assertContainsHtml(response, prev, next)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -7,7 +7,7 @@ from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.contrib import admin
 from django.shortcuts import redirect
 
-import views
+from tests.views import SimpleModelHistoryCompareView
 
 admin.autodiscover()
 
@@ -23,7 +23,7 @@ urlpatterns = patterns('',
         {'document_root': settings.MEDIA_ROOT, 'show_indexes': True}
     ),
 
-    url(r'^test_view/(?P<pk>\d+)$', views.SimpleModelHistoryCompareView.as_view() ),
+    url(r'^test_view/(?P<pk>\d+)$', SimpleModelHistoryCompareView.as_view() ),
     
     # redirect root view to admin page:
     url(r'^$', lambda x: redirect("admin:index")),

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -7,6 +7,8 @@ from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.contrib import admin
 from django.shortcuts import redirect
 
+import views
+
 admin.autodiscover()
 
 urlpatterns = patterns('',
@@ -21,6 +23,8 @@ urlpatterns = patterns('',
         {'document_root': settings.MEDIA_ROOT, 'show_indexes': True}
     ),
 
+    url(r'^test_view/(?P<pk>\d+)$', views.SimpleModelHistoryCompareView.as_view() ),
+    
     # redirect root view to admin page:
     url(r'^$', lambda x: redirect("admin:index")),
 )

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,0 +1,7 @@
+
+from reversion_compare.views import HistoryCompareDetailView
+from .models import SimpleModel
+
+class SimpleModelHistoryCompareView(HistoryCompareDetailView):
+    model = SimpleModel
+    


### PR DESCRIPTION
Changes:

* Refactor admin.py by extracting common code between admin and non-admin view and putting it to two new modules: mixins.py (for view mixins) and compare.py (for compare objects)
* Implement a HistoryCompareDetailView CBV that can be used as a normal DetailView to both display the history and select-version-form *and* the changes of the selected versions
* Fix tests so that they run under windows and add test for new CBV (by copying the tests for the SimpleModel -- probably this could be refactored a bit)
* Update README and AUTOHRS