### PR TITLE
Django 1.9 and django-reversion 1.10.0 support

### DIFF
--- a/reversion_compare/admin.py
+++ b/reversion_compare/admin.py
@@ -28,7 +28,11 @@ from django.shortcuts import get_object_or_404, render_to_response
 from django.utils.text import capfirst
 from django.utils.translation import ugettext as _
 
-import reversion
+try:
+    from reversion import revisions as reversion
+except ImportError:
+    import reversion
+
 from reversion.admin import VersionAdmin
 
 from reversion_compare.forms import SelectDiffForm

--- a/reversion_compare/compare.py
+++ b/reversion_compare/compare.py
@@ -16,7 +16,11 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.utils.translation import ugettext as _
 
-import reversion
+try:
+    from reversion import revisions as reversion
+except ImportError:
+    import reversion
+
 from reversion.models import has_int_pk
 
 logger = logging.getLogger(__name__)

--- a/setup.py
+++ b/setup.py
@@ -198,7 +198,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,  # include package data under svn source control
     install_requires=[
-        "Django>=1.7,<1.9",
+        "Django>=1.7,<1.10",
         "django-reversion>=1.8",
     ],
     tests_require=[

--- a/tests/models.py
+++ b/tests/models.py
@@ -22,7 +22,11 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-import reversion
+try:
+    from reversion import revisions as reversion
+except ImportError:
+    import reversion
+
 
 
 from django.db import models

--- a/tests/test_custom_model.py
+++ b/tests/test_custom_model.py
@@ -30,7 +30,11 @@ except ImportError as err:
     ) % err
     raise ImportError(msg)
 
-import reversion
+try:
+    from reversion import revisions as reversion
+except ImportError:
+    import reversion
+
 from reversion.models import Revision
 
 from tests.models import CustomModel

--- a/tests/test_factory_car_models.py
+++ b/tests/test_factory_car_models.py
@@ -41,7 +41,10 @@ try:
 except ImportError:
     import reversion
 
-from reversion import get_for_object
+try:
+    from reversion.revisions import get_for_object
+except ImportError:
+    from reversion import get_for_object
 from reversion.models import Revision, Version
 
 from reversion_compare import helpers

--- a/tests/test_factory_car_models.py
+++ b/tests/test_factory_car_models.py
@@ -36,7 +36,11 @@ except ImportError as err:
     raise ImportError(msg)
 from django_tools.unittest_utils.BrowserDebug import debug_response
 
-import reversion
+try:
+    from reversion import revisions as reversion
+except ImportError:
+    import reversion
+
 from reversion import get_for_object
 from reversion.models import Revision, Version
 

--- a/tests/test_factory_car_reverse_models.py
+++ b/tests/test_factory_car_reverse_models.py
@@ -41,7 +41,10 @@ try:
 except ImportError:
     import reversion
 
-from reversion import get_for_object
+try:
+    from reversion.revisions import get_for_object
+except ImportError:
+    from reversion import get_for_object
 from reversion.models import Revision, Version
 
 from reversion_compare import helpers

--- a/tests/test_factory_car_reverse_models.py
+++ b/tests/test_factory_car_reverse_models.py
@@ -36,7 +36,11 @@ except ImportError as err:
     raise ImportError(msg)
 from django_tools.unittest_utils.BrowserDebug import debug_response
 
-import reversion
+try:
+    from reversion import revisions as reversion
+except ImportError:
+    import reversion
+
 from reversion import get_for_object
 from reversion.models import Revision, Version
 

--- a/tests/test_onetoone_field.py
+++ b/tests/test_onetoone_field.py
@@ -27,7 +27,10 @@ except ImportError as err:
     ) % err
     raise ImportError(msg)
 
-from reversion import get_for_object
+try:
+    from reversion.revisions import get_for_object
+except ImportError:
+    from reversion import get_for_object
 
 from .test_utils.test_cases import BaseTestCase
 from .test_utils.test_data import TestData

--- a/tests/test_person_pet_models.py
+++ b/tests/test_person_pet_models.py
@@ -28,7 +28,11 @@ except ImportError as err:
     ) % err
     raise ImportError(msg)
 
-import reversion
+try:
+    from reversion import revisions as reversion
+except ImportError:
+    import reversion
+
 from reversion import get_for_object
 from reversion.models import Revision, Version
 

--- a/tests/test_person_pet_models.py
+++ b/tests/test_person_pet_models.py
@@ -33,7 +33,10 @@ try:
 except ImportError:
     import reversion
 
-from reversion import get_for_object
+try:
+    from reversion.revisions import get_for_object
+except ImportError:
+    from reversion import get_for_object
 from reversion.models import Revision, Version
 
 from tests.models import Person, Pet

--- a/tests/test_simple_model.py
+++ b/tests/test_simple_model.py
@@ -37,7 +37,11 @@ except ImportError as err:
     raise ImportError(msg)
 from django_tools.unittest_utils.BrowserDebug import debug_response
 
-import reversion
+try:
+    from reversion import revisions as reversion
+except ImportError:
+    import reversion
+
 from reversion import get_for_object
 from reversion.models import Revision, Version
 

--- a/tests/test_simple_model.py
+++ b/tests/test_simple_model.py
@@ -42,7 +42,10 @@ try:
 except ImportError:
     import reversion
 
-from reversion import get_for_object
+try:
+    from reversion.revisions import get_for_object
+except ImportError:
+    from reversion import get_for_object
 from reversion.models import Revision, Version
 
 from reversion_compare import helpers

--- a/tests/test_utils/test_cases.py
+++ b/tests/test_utils/test_cases.py
@@ -31,7 +31,11 @@ except ImportError as err:
     raise ImportError(msg)
 from django_tools.unittest_utils.BrowserDebug import debug_response
 
-import reversion
+try:
+    from reversion import revisions as reversion
+except ImportError:
+    import reversion
+
 from reversion.models import Revision, Version
 
 from reversion_compare import helpers

--- a/tests/test_utils/test_data.py
+++ b/tests/test_utils/test_data.py
@@ -35,7 +35,11 @@ except ImportError as err:
     ) % err
     raise ImportError(msg)
 
-import reversion
+try:
+    from reversion import revisions as reversion
+except ImportError:
+    import reversion
+
 
 from tests.models import SimpleModel, Person, Pet, \
     Factory, Car, VariantModel, CustomModel, Identity

--- a/tests/test_variant_model.py
+++ b/tests/test_variant_model.py
@@ -36,7 +36,10 @@ try:
 except ImportError:
     import reversion
 
-from reversion import get_for_object
+try:
+    from reversion.revisions import get_for_object
+except ImportError:
+    from reversion import get_for_object
 from reversion.models import Revision
 
 from tests.models import VariantModel

--- a/tests/test_variant_model.py
+++ b/tests/test_variant_model.py
@@ -31,7 +31,11 @@ except ImportError as err:
     raise ImportError(msg)
 from django_tools.unittest_utils.BrowserDebug import debug_response
 
-import reversion
+try:
+    from reversion import revisions as reversion
+except ImportError:
+    import reversion
+
 from reversion import get_for_object
 from reversion.models import Revision
 

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -38,7 +38,10 @@ try:
 except ImportError:
     import reversion
 
-from reversion import get_for_object
+try:
+    from reversion.revisions import get_for_object
+except ImportError:
+    from reversion import get_for_object
 from reversion.models import Revision, Version
 
 from reversion_compare import helpers

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -33,7 +33,11 @@ except ImportError as err:
     raise ImportError(msg)
 from django_tools.unittest_utils.BrowserDebug import debug_response
 
-import reversion
+try:
+    from reversion import revisions as reversion
+except ImportError:
+    import reversion
+
 from reversion import get_for_object
 from reversion.models import Revision, Version
 


### PR DESCRIPTION
`import reversion` no longer works on the latest `django-reversion`.

I also changed `setup.py` so that it doesn't insist on downgrading `Django`.