### PR TITLE
Fix Python error when ManyToMany relations didn't exist.

### DIFF
--- a/reversion_compare/compare.py
+++ b/reversion_compare/compare.py
@@ -31,7 +31,7 @@ class FieldVersionDoesNotExist(object):
     """
 
     def __str__(self):
-        return force_text(_("Field Didn't exist!"))
+        return force_text(_("Field didn't exist!"))
 
 DOES_NOT_EXIST = FieldVersionDoesNotExist()
 

--- a/reversion_compare/locale/el/LC_MESSAGES/django.po
+++ b/reversion_compare/locale/el/LC_MESSAGES/django.po
@@ -24,7 +24,7 @@ msgid "Compare %(name)s"
 msgstr "Σύγκριση %(name)s"
 
 #: .\compare.py:34
-msgid "Field Didn't exist!"
+msgid "Field didn't exist!"
 msgstr "Το πεδίο δεν υπήρχε"
 
 #: .\templates\reversion-compare\action_list_partial.html:9

--- a/reversion_compare/locale/nl/LC_MESSAGES/django.po
+++ b/reversion_compare/locale/nl/LC_MESSAGES/django.po
@@ -24,7 +24,7 @@ msgid "Compare %(name)s"
 msgstr "Vergelijk %(name)s"
 
 #: .\compare.py:34
-msgid "Field Didn't exist!"
+msgid "Field didn't exist!"
 msgstr "Veld bestond niet!"
 
 #: .\templates\reversion-compare\action_list_partial.html:9


### PR DESCRIPTION
This avoids storing an ugettext value in self.version.
It's value got parsed in `ids = [int(v) for v in self.value]`
causing an `int("F")` call that fails.

Instead, a sentinal value is introduced that can be recognized in the
code, yet output a meaningful message when it's shown to the user.

Fixes #44 

This is a rebased version of #54