### PR TITLE
Check if related model has an integer as pk for ManyToMany fields.

### DIFF
--- a/reversion_compare/compare.py
+++ b/reversion_compare/compare.py
@@ -137,12 +137,13 @@ class CompareObject(object):
         elif self.value is DOES_NOT_EXIST:
             return ([], [], [], [])  # TODO: refactory that
 
+        related_model = self.field.rel.to
+
         ids = None
-        if self.has_int_pk:
+        if reversion_api.has_int_pk(related_model):
             ids = [int(v) for v in self.value]  # is: version.field_dict[field.name]
 
         # Get the related model of the current field:
-        related_model = self.field.rel.to
         return self.get_many_to_something(ids, related_model)
 
     def get_many_to_something(self, ids, related_model, is_reverse=False):


### PR DESCRIPTION
I have a model (Station) that uses UUID as pk, and it has an ManyToMany relation to a model (Entity) that uses integers as pk. With current implementation I get an exception because Station.has_int_pk() returns False (as it should), so ids is None when we call `get_many_to_something()`. It should check if the related model has integers as pk, because it's the related model ids when want in our query.

I guess there should be an else statement where ids is set to `self.value`, if the related model uses string as pk?