### PR TITLE
setup.py - don't package tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -202,7 +202,7 @@ setup(
     maintainer_email="django-reversion-compare@jensdiemer.de",
     url='https://github.com/jedie/django-reversion-compare/',
     download_url='http://pypi.python.org/pypi/django-reversion-compare/',
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,
     install_requires=[
         "Django>=1.8,<1.10",


### PR DESCRIPTION
Found them sitting in my installed packages :scream:

Checked in shell:

```
In [2]: find_packages()
Out[2]:
['reversion_compare',
 'tests',
 'tests.management',
 'tests.test_utils',
 'tests.management.commands']

In [3]: find_packages(exclude=['tests', 'tests.*'])
Out[3]: ['reversion_compare']
```