### PR TITLE
Fix case when model has template field which is ForeignKey

### DIFF
--- a/reversion_compare/mixins.py
+++ b/reversion_compare/mixins.py
@@ -47,7 +47,8 @@ class CompareMixin(object, ):
             func_name = "compare_%s" % suffix
             if hasattr(self, func_name):
                 func = getattr(self, func_name)
-                return func
+                if callable(func):
+                    return func
 
         # Try method in the name scheme: "compare_%s" % field_name
         func = _get_compare_func(obj_compare.field_name)

--- a/reversion_compare_tests/admin.py
+++ b/reversion_compare_tests/admin.py
@@ -16,7 +16,7 @@ from django.contrib import admin
 from reversion_compare.admin import CompareVersionAdmin
 
 from .models import SimpleModel, Factory, Car, Person, Pet,\
-    VariantModel, CustomModel, Identity
+    VariantModel, CustomModel, Identity, TemplateField
 
 
 class SimpleModelAdmin(CompareVersionAdmin):
@@ -55,6 +55,12 @@ class CustomModelAdmin(CompareVersionAdmin):
 admin.site.register(CustomModel, CustomModelAdmin)
 
 admin.site.register(Identity, CustomModelAdmin)
+
+
+class TemplateFieldModelAdmin(CompareVersionAdmin):
+    pass
+
+admin.site.register(TemplateField, TemplateFieldModelAdmin)
 
 
 """

--- a/reversion_compare_tests/models.py
+++ b/reversion_compare_tests/models.py
@@ -157,6 +157,16 @@ class CustomModel(models.Model):
     """Model which uses a custom version manager."""
     text = models.TextField()
 
+
+class TemplateField(models.Model):
+    """VersionAdmin in django-reversion has field compare_template that is str
+    Model used for check correct handling this case
+    Should be used ForeignKey for calling mixins.CompareMixin._get_compare_func
+    """
+    # some field for easy creating revisions
+    text = models.CharField(max_length=20)
+    template = models.ForeignKey(Person, blank=True, null=True)
+
 """
 @python_2_unicode_compatible
 class ParentModel(models.Model):

--- a/reversion_compare_tests/test_template_field_model.py
+++ b/reversion_compare_tests/test_template_field_model.py
@@ -19,8 +19,7 @@ from __future__ import absolute_import, division, print_function
 
 import unittest
 
-from reversion import is_registered
-from reversion.models import Version, Revision
+from reversion.models import Version
 from reversion_compare import helpers
 
 try:
@@ -46,7 +45,6 @@ class TemplateFieldModelTest(BaseTestCase):
     def setUp(self):
         super(TemplateFieldModelTest, self).setUp()
         test_data = TestData(verbose=False)
-        # test_data = TestData(verbose=True)
         self.item1, self.item2 = test_data.create_TemplateField_data()
 
         queryset = Version.objects.get_for_object(self.item1)

--- a/reversion_compare_tests/test_template_field_model.py
+++ b/reversion_compare_tests/test_template_field_model.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+"""
+    django-reversion-compare unittests
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    I used the setup from reversion_compare_test_project !
+
+    TODO:
+        * models.OneToOneField()
+        * models.IntegerField()
+
+    :copyleft: 2012-2016 by the django-reversion-compare team, see AUTHORS for more details.
+    :license: GNU GPL v3 or above, see LICENSE for more details.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import unittest
+
+from reversion import is_registered
+from reversion.models import Version, Revision
+from reversion_compare import helpers
+
+try:
+    import django_tools
+except ImportError as err:
+    msg = (
+        "Please install django-tools for unittests"
+        " - https://github.com/jedie/django-tools/"
+        " - Original error: %s"
+    ) % err
+    raise ImportError(msg)
+
+from .test_utils.test_cases import BaseTestCase
+from .test_utils.test_data import TestData
+
+
+class TemplateFieldModelTest(BaseTestCase):
+    """
+    unittests that used reversion_compare_test_app.models.SimpleModel
+
+    Tests for the basic functions.
+    """
+    def setUp(self):
+        super(TemplateFieldModelTest, self).setUp()
+        test_data = TestData(verbose=False)
+        # test_data = TestData(verbose=True)
+        self.item1, self.item2 = test_data.create_TemplateField_data()
+
+        queryset = Version.objects.get_for_object(self.item1)
+        self.version_ids1 = queryset.values_list("pk", flat=True)
+
+        queryset = Version.objects.get_for_object(self.item2)
+        self.version_ids2 = queryset.values_list("pk", flat=True)
+
+    def test_diff(self):
+        response = self.client.get(
+            "/admin/reversion_compare_tests/templatefield/%s/history/compare/" % self.item1.pk,
+            data={"version_id2": self.version_ids1[0], "version_id1": self.version_ids1[1]}
+        )
+        # debug_response(response) # from django-tools
+        self.assertContainsHtml(
+            response,
+            '<del>- version one</del>',
+            '<ins>+ version two</ins>',
+            '<blockquote>simply change the CharField text.</blockquote>',  # edit comment
+        )
+
+    @unittest.skipIf(not hasattr(helpers, "diff_match_patch"), "No google-diff-match-patch available")
+    def test_google_diff_match_patch(self):
+        self.activate_google_diff_match_patch()
+        response = self.client.get(
+            "/admin/reversion_compare_tests/templatefield/%s/history/compare/" % self.item1.pk,
+            data={"version_id2": self.version_ids1[0], "version_id1": self.version_ids1[1]}
+        )
+        # debug_response(response) # from django-tools
+        self.assertContainsHtml(
+            response,
+            """
+            <p><span>version </span>
+            <del style="background:#ffe6e6;">one</del>
+            <ins style="background:#e6ffe6;">two</ins>
+            </p>
+            """,
+            '<blockquote>simply change the CharField text.</blockquote>',  # edit comment
+        )

--- a/reversion_compare_tests/test_utils/test_data.py
+++ b/reversion_compare_tests/test_utils/test_data.py
@@ -38,7 +38,8 @@ except ImportError as err:
     ) % err
     raise ImportError(msg)
 
-from reversion_compare_tests.models import SimpleModel, Person, Pet, Factory, Car, VariantModel, CustomModel, Identity
+from reversion_compare_tests.models import SimpleModel, Person, Pet, Factory, Car, VariantModel, CustomModel, Identity, \
+    TemplateField
 
 
 class TestData(object):
@@ -391,4 +392,31 @@ class TestData(object):
             set_comment("version 2: change person name.")
 
         return person, identity
+
+    def create_TemplateField_data(self):
+        with create_revision():
+            item1 = TemplateField.objects.create(text="version one")
+
+        if self.verbose:
+            print("version 1:", item1)
+
+        with create_revision():
+            item1.text = "version two"
+            item1.save()
+            set_comment("simply change the CharField text.")
+
+        if self.verbose:
+            print("version 2:", item1)
+
+        for no in range(5):
+            with create_revision():
+                if no == 0:
+                    item2 = TemplateField.objects.create(text="v0")
+                    set_comment("create v%i" % no)
+                else:
+                    item2.text = "v%i" % no
+                    item2.save()
+                    set_comment("change to v%i" % no)
+
+        return item1, item2
 


### PR DESCRIPTION
When model has field with name "template" and has ForeignKey type next code
```
def _get_compare_func(suffix):
            # logger.debug("func_name: %s", func_name)
            func_name = "compare_%s" % suffix
            if hasattr(self, func_name):
                func = getattr(self, func_name)
                if callable(func):
                    return func
```
get `compare_template` field from `VersionAdmin` class which is `str` object, not callable.