### PR TITLE
Show username and full name from custom user model

### DIFF
--- a/reversion_compare/templates/reversion-compare/action_list_partial.html
+++ b/reversion_compare/templates/reversion-compare/action_list_partial.html
@@ -39,8 +39,8 @@
                 </th>
                 <td>
                     {% if action.revision.user %}
-                        {{action.revision.user.username}}
-                        {% if action.revision.user.first_name %} ({{action.revision.user.first_name}} {{action.revision.user.last_name}}){% endif %}
+                        {{action.revision.user.get_username}}
+                        {% if action.revision.user.get_full_name %} ({{action.revision.user.get_full_name}}){% endif %}
                     {% endif %}
                 </td>
                 <td>{{action.revision.comment|default:""}}</td>


### PR DESCRIPTION
This is the port of the commit https://github.com/etianen/django-reversion/commit/ae82a832bd353d83ab281305deb0967e9110c503 from the original django-reversion template.

Without this patch, the `User` column in the object history view is always empty if your User model doesn't have a username or full name.