### PR TITLE
actually check if model is registered

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -62,5 +62,5 @@ CONTRIBUTORS are and/or have been (alphabetic order):
   Github: <https://github.com/w4rri0r3k>
 * Wickström, Frank
   Github: <https://github.com/frwickst>
-* Willemsm, Thomas
+* Willems, Thomas
   Github: <https://github.com/willtho89>


### PR DESCRIPTION
I just got a ping because  #114 got merged. 
Thanks to @baffolobill's fork I noticed that reversion actually has a check to see if a model is registered. So I used that instead of the uglier try/except. Additionally to @baffolobill's fork, I still use `REVERSION_COMPARE_IGNORE_NOT_REGISTERED`.

Unfortunately I forgot to update my initial PR :-( so here it goes again

(further fixes #103)