### PR TITLE
Add Django version 3.0 to the project dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ python = "^3.6"
 #
 # https://www.djangoproject.com/download/#supported-versions
 # v2.2 LTS - extended support until April 2022
-django = "2.2.*"
+django = ">=2.2, <3.1"
 django-reversion = "*"
 diff-match-patch = "*"
 


### PR DESCRIPTION
The README says it's compatible with Django 3.0 but the pyproject.toml only specifies 2.2.*