### PR TITLE
Allow use Django>=3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
     "Framework :: Django",
     "Framework :: Django :: 2.2",
+    "Framework :: Django :: 3.0",
+    "Framework :: Django :: 3.1",
     "Operating System :: OS Independent",
     "Topic :: Database :: Front-Ends",
     "Topic :: Documentation",
@@ -38,10 +40,6 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.6"
-#
-# https://www.djangoproject.com/download/#supported-versions
-# v2.2 LTS - extended support until April 2022
-django = ">=2.2, <3.1"
 django-reversion = "*"
 diff-match-patch = "*"
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -19,7 +19,7 @@ addopts =
     --doctest-modules
 
     # We used logging config in django, so: disable printing caught logs on failed tests.
-    --no-print-logs
+    --show-capture=no
 
     # run the last failures first:
     --failed-first

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-envlist = {py38,py37,py36,pypy3}-django{22,30}
+envlist = {py38,py37,py36,pypy3}-django{22,30,31}
 skip_missing_interpreters = True
 
 [gh-actions]
@@ -15,6 +15,7 @@ python =
 deps =
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2
 
 whitelist_externals = make
 commands =


### PR DESCRIPTION
* Add `Django==3.1` to tox test matrix
* Remove direct Django dependency (as suggested in #131)
* Fix `pytest` arguments after [6.0 released](https://docs.pytest.org/en/stable/changelog.html#id19) 