### PR TITLE
Multiline diff formatting improvements #137

### DIFF
--- a/reversion_compare/templates/reversion-compare/compare.html
+++ b/reversion_compare/templates/reversion-compare/compare.html
@@ -6,15 +6,25 @@
     /* minimal style for the diffs */
     pre.highlight {
         max-width: 900px;
-        white-space: pre-line;
     }
     del, ins {
         color: #000;
         text-decoration: none;
     }
-    del { background-color: #ffe6e6; }
-    ins { background-color: #e6ffe6; }
+    del { background-color: #fdb8c0 }
+    ins { background-color: #acf2bd; }
     sup.follow { color: #5555ff; }
+    .diff-line {
+      display: inline-block;
+      width: 100%;
+      margin-left: -1.0em;
+      padding-left: 0.5em;
+      background-color: #f6f6f6;
+      color: #222;
+    }
+    .diff-line.diff-ins { border-left: 0.5em solid #bef5cb; background-color: #e6ffed; }
+    .diff-line.diff-del { border-left: 0.5em solid #fdaeb7; background-color: #ffeef0; }
+    .diff-line.diff-ins.diff-del { border-left: 0.5em solid #bef5cb; background-color: #e6ffed; } /* mixed del/ins == green */
 </style>
 {% endblock %}
 

--- a/reversion_compare_tests/test_helpers.py
+++ b/reversion_compare_tests/test_helpers.py
@@ -1,4 +1,10 @@
-from reversion_compare.helpers import EFFICIENCY, SEMANTIC, generate_dmp_diff, generate_ndiff, html_diff
+from reversion_compare.helpers import EFFICIENCY, SEMANTIC, generate_dmp_diff, generate_ndiff, html_diff, diff2lines, lines2html
+
+from diff_match_patch import diff_match_patch
+
+DIFF_EQUAL = diff_match_patch.DIFF_EQUAL
+DIFF_INSERT = diff_match_patch.DIFF_INSERT
+DIFF_DELETE = diff_match_patch.DIFF_DELETE
 
 
 def test_generate_ndiff():
@@ -32,7 +38,11 @@ def test_generate_dmp_diff():
         value1='one',
         value2='two',
     )
-    assert html == '<pre class="highlight"><del>one</del><ins>two</ins></pre>'
+    assert html == (
+        '<pre class="highlight">'
+        '<span class="diff-line diff-del diff-ins"><del>one</del><ins>two</ins></span>\n'
+        '</pre>'
+    )
 
     html = generate_dmp_diff(
         value1='aaa\nccc\nddd\n',
@@ -40,9 +50,9 @@ def test_generate_dmp_diff():
     )
     assert html == (
         '<pre class="highlight">aaa\n'
-        '<del>ccc\n'
-        'ddd</del><ins>bbb\n'
-        'ccc</ins>\n'
+        '<span class="diff-line diff-del"><del>ccc</del></span>\n'
+        '<span class="diff-line diff-del diff-ins"><del>ddd</del><ins>bbb</ins></span>\n'
+        '<span class="diff-line diff-ins"><ins>ccc</ins></span>\n'
         '</pre>'
     )
 
@@ -56,7 +66,11 @@ def test_generate_dmp_diff_no_cleanup():
         value2='two',
         cleanup=None
     )
-    assert html == '<pre class="highlight"><ins>tw</ins>o<del>ne</del></pre>'
+    assert html == (
+        '<pre class="highlight">'
+        '<span class="diff-line diff-del diff-ins"><ins>tw</ins>o<del>ne</del></span>\n'
+        '</pre>'
+    )
 
     html = generate_dmp_diff(
         value1='aaa\nccc\nddd\n',
@@ -64,12 +78,10 @@ def test_generate_dmp_diff_no_cleanup():
         cleanup=None
     )
     assert html == (
-        '<pre class="highlight">'
-        'aaa\n'
-        '<ins>bbb\n'
-        '</ins>ccc\n'
-        '<del>ddd\n'
-        '</del>'
+        '<pre class="highlight">aaa\n'
+        '<span class="diff-line diff-ins"><ins>bbb</ins></span>\n'
+        'ccc\n'
+        '<span class="diff-line diff-del"><del>ddd</del></span>\n'
         '</pre>'
     )
 
@@ -83,7 +95,11 @@ def test_generate_dmp_diff_efficiency():
         value2='two',
         cleanup=EFFICIENCY
     )
-    assert html == '<pre class="highlight"><ins>tw</ins>o<del>ne</del></pre>'
+    assert html == (
+        '<pre class="highlight">'
+        '<span class="diff-line diff-del diff-ins"><ins>tw</ins>o<del>ne</del></span>\n'
+        '</pre>'
+    )
 
     html = generate_dmp_diff(
         value1='aaa\nccc\nddd\n',
@@ -91,12 +107,10 @@ def test_generate_dmp_diff_efficiency():
         cleanup=EFFICIENCY
     )
     assert html == (
-        '<pre class="highlight">'
-        'aaa\n'
-        '<ins>bbb\n'
-        '</ins>ccc\n'
-        '<del>ddd\n'
-        '</del>'
+        '<pre class="highlight">aaa\n'
+        '<span class="diff-line diff-ins"><ins>bbb</ins></span>\n'
+        'ccc\n'
+        '<span class="diff-line diff-del"><del>ddd</del></span>\n'
         '</pre>'
     )
 
@@ -112,8 +126,8 @@ def test_generate_dmp_diff_semantic():
     )
     assert html == (
         '<pre class="highlight">'
-        'xxx<del>1</del><ins>2</ins>xxx\n'
-        'X'
+        '<span class="diff-line diff-del diff-ins">xxx<del>1</del><ins>2</ins>xxx</span>\n'
+        'X\n'
         '</pre>'
     )
 
@@ -124,7 +138,7 @@ def test_generate_dmp_diff_semantic():
     )
     assert html == (
         '<pre class="highlight">'
-        '<del>one</del><ins>two</ins>'
+        '<span class="diff-line diff-del diff-ins"><del>one</del><ins>two</ins></span>\n'
         '</pre>'
     )
 
@@ -134,11 +148,10 @@ def test_generate_dmp_diff_semantic():
         cleanup=SEMANTIC
     )
     assert html == (
-        '<pre class="highlight">'
-        'aaa\n'
-        '<del>ccc\n'
-        'ddd</del><ins>bbb\n'
-        'ccc</ins>\n'
+        '<pre class="highlight">aaa\n'
+        '<span class="diff-line diff-del"><del>ccc</del></span>\n'
+        '<span class="diff-line diff-del diff-ins"><del>ddd</del><ins>bbb</ins></span>\n'
+        '<span class="diff-line diff-ins"><ins>ccc</ins></span>\n'
         '</pre>'
     )
 
@@ -158,6 +171,77 @@ def test_html_diff():
     )
     assert html == (
         '<pre class="highlight">'
-        '<del>m</del><ins>M</ins>ore than 20 <del>C</del><ins>c</ins>haracters<ins>,</ins> or?'
+        '<span class="diff-line diff-del diff-ins"><del>m</del><ins>M</ins>ore than 20 <del>C</del><ins>c</ins>haracters<ins>,</ins> or?</span>\n'
         '</pre>'
+    )
+
+def test_diff2lines():
+    assert list(diff2lines(
+        [
+            (DIFF_EQUAL, 'equal\ntext'),
+            (DIFF_DELETE, 'deleted\n'),
+            (DIFF_INSERT, 'added\ntext'),
+        ]
+    )) == [
+        [(DIFF_EQUAL, 'equal')],
+        [(DIFF_EQUAL, 'text'), (DIFF_DELETE, 'deleted')],
+        [(DIFF_INSERT, 'added')],
+        [(DIFF_INSERT, 'text')],
+    ]
+
+    # html escaping
+    assert list(diff2lines(
+        [
+            (DIFF_EQUAL, '<equal>\ntext'),
+            (DIFF_DELETE, '&deleted\n'),
+            (DIFF_INSERT, 'added\ntext'),
+        ]
+    )) == [
+        [(DIFF_EQUAL, '&lt;equal&gt;')],
+        [(DIFF_EQUAL, 'text'), (DIFF_DELETE, '&amp;deleted')],
+        [(DIFF_INSERT, 'added')],
+        [(DIFF_INSERT, 'text')],
+    ]
+
+    # \r\n line feeds
+    assert list(diff2lines(
+        [
+            (DIFF_EQUAL, 'equal\r\ntext'),
+            (DIFF_DELETE, 'deleted\r\n'),
+            (DIFF_INSERT, 'added\r\ntext'),
+        ]
+    )) == [
+        [(DIFF_EQUAL, 'equal')],
+        [(DIFF_EQUAL, 'text'), (DIFF_DELETE, 'deleted')],
+        [(DIFF_INSERT, 'added')],
+        [(DIFF_INSERT, 'text')],
+    ]
+
+    # Whitespace is retained
+    assert list(diff2lines(
+        [
+            (DIFF_EQUAL, 'equal\ntext   '),
+            (DIFF_DELETE, 'deleted\n'),
+            (DIFF_INSERT, 'added\n   text'),
+        ]
+    )) == [
+        [(DIFF_EQUAL, 'equal')],
+        [(DIFF_EQUAL, 'text   '), (DIFF_DELETE, 'deleted')],
+        [(DIFF_INSERT, 'added')],
+        [(DIFF_INSERT, '   text')],
+    ]
+
+def test_lines2html():
+    assert lines2html(
+        [
+            [(DIFF_EQUAL, 'equal')],
+            [(DIFF_EQUAL, 'text'), (DIFF_DELETE, 'deleted'), (DIFF_DELETE, '')],
+            [(DIFF_INSERT, 'added')],
+            [(DIFF_INSERT, 'text'), (DIFF_DELETE, 'removed')],
+        ]
+    ) == (
+        'equal\n'
+        '<span class="diff-line diff-del">text<del>deleted</del><del>⏎</del></span>\n'
+        '<span class="diff-line diff-ins"><ins>added</ins></span>\n'
+        '<span class="diff-line diff-del diff-ins"><ins>text</ins><del>removed</del></span>\n'
     )

--- a/reversion_compare_tests/test_helpers.py
+++ b/reversion_compare_tests/test_helpers.py
@@ -1,6 +1,15 @@
-from reversion_compare.helpers import EFFICIENCY, SEMANTIC, generate_dmp_diff, generate_ndiff, html_diff, diff2lines, lines2html
-
 from diff_match_patch import diff_match_patch
+
+from reversion_compare.helpers import (
+    EFFICIENCY,
+    SEMANTIC,
+    diff2lines,
+    generate_dmp_diff,
+    generate_ndiff,
+    html_diff,
+    lines2html,
+)
+
 
 DIFF_EQUAL = diff_match_patch.DIFF_EQUAL
 DIFF_INSERT = diff_match_patch.DIFF_INSERT
@@ -171,9 +180,12 @@ def test_html_diff():
     )
     assert html == (
         '<pre class="highlight">'
-        '<span class="diff-line diff-del diff-ins"><del>m</del><ins>M</ins>ore than 20 <del>C</del><ins>c</ins>haracters<ins>,</ins> or?</span>\n'
+        '<span class="diff-line diff-del diff-ins">'
+        '<del>m</del><ins>M</ins>ore than 20 <del>C</del><ins>c</ins>haracters<ins>,</ins> or?'
+        '</span>\n'
         '</pre>'
     )
+
 
 def test_diff2lines():
     assert list(diff2lines(
@@ -230,6 +242,7 @@ def test_diff2lines():
         [(DIFF_INSERT, 'added')],
         [(DIFF_INSERT, '   text')],
     ]
+
 
 def test_lines2html():
     assert lines2html(

--- a/reversion_compare_tests/test_variant_model.py
+++ b/reversion_compare_tests/test_variant_model.py
@@ -147,24 +147,28 @@ class VariantModelWithDataTest(BaseTestCase):
             "<h3>url</h3>",
             """
             <div class="module">
-                <pre class="highlight"><span class="diff-line diff-del diff-ins">http<ins>s</ins>://<del>www.pylucid.org</del><ins>github.com/jedie</ins>/</span>
-        </pre>
+                <pre class="highlight">
+                <span class="diff-line diff-del diff-ins">http<ins>s</ins>://
+                <del>www.pylucid.org</del><ins>github.com/jedie</ins>/</span>
+                </pre>
             </div>
             """,
 
             "<h3>file field</h3>",
             f"""
             <div class="module">
-                <pre class="highlight"><span class="diff-line diff-del diff-ins">{settings.UNITTEST_TEMP_PATH}/<del>foo</del><ins>bar</ins></span>
-        </pre>
+            <pre class="highlight"><span class="diff-line diff-del diff-ins">
+            {settings.UNITTEST_TEMP_PATH}/<del>foo</del><ins>bar</ins></span>
+            </pre>
             </div>
             """,
 
             "<h3>filepath</h3>",
             f"""
             <div class="module">
-                <pre class="highlight"><span class="diff-line diff-del diff-ins">{settings.UNITTEST_TEMP_PATH}/<del>foo</del><ins>bar</ins></span>
-        </pre>
+            <pre class="highlight"><span class="diff-line diff-del diff-ins">
+            {settings.UNITTEST_TEMP_PATH}/<del>foo</del><ins>bar</ins></span>
+            </pre>
             </div>
             """,
 

--- a/reversion_compare_tests/test_variant_model.py
+++ b/reversion_compare_tests/test_variant_model.py
@@ -147,27 +147,24 @@ class VariantModelWithDataTest(BaseTestCase):
             "<h3>url</h3>",
             """
             <div class="module">
-                <pre class="highlight">
-                    http<ins>s</ins>://<del>www.pylucid.org</del><ins>github.com/jedie</ins>/
-                </pre>
+                <pre class="highlight"><span class="diff-line diff-del diff-ins">http<ins>s</ins>://<del>www.pylucid.org</del><ins>github.com/jedie</ins>/</span>
+        </pre>
             </div>
             """,
 
             "<h3>file field</h3>",
             f"""
             <div class="module">
-                <pre class="highlight">
-                    /media{settings.UNITTEST_TEMP_PATH}/<del>foo</del><ins>bar</ins>
-                </pre>
+                <pre class="highlight"><span class="diff-line diff-del diff-ins">{settings.UNITTEST_TEMP_PATH}/<del>foo</del><ins>bar</ins></span>
+        </pre>
             </div>
             """,
 
             "<h3>filepath</h3>",
             f"""
             <div class="module">
-                <pre class="highlight">
-                    {settings.UNITTEST_TEMP_PATH}/<del>foo</del><ins>bar</ins>
-                </pre>
+                <pre class="highlight"><span class="diff-line diff-del diff-ins">{settings.UNITTEST_TEMP_PATH}/<del>foo</del><ins>bar</ins></span>
+        </pre>
             </div>
             """,
 


### PR DESCRIPTION
Squashed commit of the following:

commit d48d60cb40090c7fb2c8b6a97a134100e12f07a0
Author: Dan Bader <mail@dbader.org>
Date:   Mon Dec 14 09:55:24 2020 -0800

    Make diff lines full-width

commit b17c63359dcbd9ac0c704a18c11875202d7d7fbe
Author: Dan Bader <mail@dbader.org>
Date:   Sun Dec 13 18:51:59 2020 -0800

    Cleanup; add docstrings

commit ad0383cdc4e1822d014483839c7d69e9747c0548
Author: Dan Bader <mail@dbader.org>
Date:   Sun Dec 13 12:59:45 2020 -0800

    Update diff color scheme

commit 9f4ac80d2991dbb8c87614ad1d4388711cbc0e4e
Author: Dan Bader <mail@dbader.org>
Date:   Sun Dec 13 12:59:28 2020 -0800

    Fix diff_match_patch_pretty_html HTML spans

commit 1ed6665be6f4359b8a89e153383fc9f6b89cbe4b
Author: Dan Bader <mail@dbader.org>
Date:   Sat Dec 12 16:39:05 2020 -0800

    Fix line end handling, update tests

commit 111e59b08b55a6f05d431dfc26df5a805cfe7b31
Author: Dan Bader <mail@dbader.org>
Date:   Sat Dec 12 16:10:35 2020 -0800

    Update test_variant_model.py

commit dd7fc4d1499395bcb6e76233e5529958f236665a
Author: Dan Bader <mail@dbader.org>
Date:   Sat Dec 12 16:10:18 2020 -0800

    Fix NullBooleanField deprecation warning

commit 13a38f6728365b7fad52df4cba9c6af004493dc0
Author: Dan Bader <mail@dbader.org>
Date:   Sat Dec 12 11:33:46 2020 -0800

    Update test_helpers.py

commit ca21fa765580f066542b0da343638803e3d85d7b
Author: Dan Bader <mail@dbader.org>
Date:   Sat Dec 12 10:24:00 2020 -0800

    Diff viewer improvements: Don't assume \r\n line endings

commit 173429c8321e1530eb31988fde6880c245cb25f3
Author: Dan Bader <mail@dbader.org>
Date:   Fri Dec 11 18:03:33 2020 -0800

    Multiline diff improvements

    - mark modified lines
    - fix <pre> whitespace