### PR TITLE
Fix line breaks on long lines in diff

### DIFF
--- a/reversion_compare/templates/reversion-compare/compare.html
+++ b/reversion_compare/templates/reversion-compare/compare.html
@@ -6,6 +6,7 @@
     /* minimal style for the diffs */
     pre.highlight {
         max-width: 900px;
+        white-space: pre-line;
     }
     del, ins {
         color: #000;


### PR DESCRIPTION
@jedie Quick heads up, I just upgraded to 0.13.1 and noticed that this change breaks line wrapping. Here's what it's supposed to look like (with `white-space: pre-line`):

![Screen Shot 2021-02-09 at 9 42 25 AM](https://user-images.githubusercontent.com/306708/107404585-4987d780-6abb-11eb-9bd0-3f63a9b8048a.png)

Here's what it currently looks like in 0.13.1 (no `white-space: pre-line`):

![Screen Shot 2021-02-09 at 9 42 47 AM](https://user-images.githubusercontent.com/306708/107404551-3ffe6f80-6abb-11eb-9407-12fbf74cf38d.png)

Without `white-space: pre-line`, long lines extend past the max-width instead of wrapping, and the diff looks broken as a result.

There was probably another reason why you removed the `white-space` setting? Or was it accidental? Here's a quick PR to ad it back.

(https://github.com/jedie/django-reversion-compare/pull/144#discussion_r573092921)