### PR TITLE
Speed up Revision/Version admin with raw_id_fields and list_select_related

### DIFF
--- a/reversion_compare/admin.py
+++ b/reversion_compare/admin.py
@@ -278,6 +278,7 @@ if hasattr(settings, "ADD_REVERSION_ADMIN") and settings.ADD_REVERSION_ADMIN:
         list_display = ("object_repr", "comment", "object_id", "content_type", "format")
         list_display_links = ("object_repr", "object_id")
         list_filter = ("content_type", "format")
+        list_select_related = ("revision", "content_type")
         search_fields = ("object_repr", "serialized_data")
         raw_id_fields = ("revision",)
 

--- a/reversion_compare/admin.py
+++ b/reversion_compare/admin.py
@@ -268,6 +268,7 @@ if hasattr(settings, "ADD_REVERSION_ADMIN") and settings.ADD_REVERSION_ADMIN:
         ordering = ("-date_created",)
         list_filter = ("user", "comment")
         search_fields = ("user", "comment")
+        raw_id_fields = ("user",)
 
     admin.site.register(Revision, RevisionAdmin)
 
@@ -278,5 +279,6 @@ if hasattr(settings, "ADD_REVERSION_ADMIN") and settings.ADD_REVERSION_ADMIN:
         list_display_links = ("object_repr", "object_id")
         list_filter = ("content_type", "format")
         search_fields = ("object_repr", "serialized_data")
+        raw_id_fields = ("revision",)
 
     admin.site.register(Version, VersionAdmin)

--- a/reversion_compare/admin.py
+++ b/reversion_compare/admin.py
@@ -264,6 +264,7 @@ if hasattr(settings, "ADD_REVERSION_ADMIN") and settings.ADD_REVERSION_ADMIN:
     class RevisionAdmin(admin.ModelAdmin):
         list_display = ("id", "date_created", "user", "comment")
         list_display_links = ("date_created",)
+        list_select_related = ("user",)
         date_hierarchy = "date_created"
         ordering = ("-date_created",)
         list_filter = ("user", "comment")


### PR DESCRIPTION
This should prevent those admin pages from executing potentially thousands of queries. Refs #152.