### PR TITLE
Enable diff-match-patch "checklines" mode for better diffs

### DIFF
--- a/reversion_compare/helpers.py
+++ b/reversion_compare/helpers.py
@@ -146,7 +146,7 @@ def generate_dmp_diff(value1, value2, cleanup=SEMANTIC):
     """
     diff = dmp.diff_main(
         value1, value2,
-        checklines=False  # run a line-level diff first to identify the changed areas
+        checklines=True  # run a line-level diff first to identify the changed areas
     )
     if cleanup == SEMANTIC:
         dmp.diff_cleanupSemantic(diff)


### PR DESCRIPTION
This seems to generate much cleaner diffs for long texts with many edits. With `checklines=False` we usually end up with a "delete old text, insert new text" diff that's not very useful.

`checklines=True` is the default in `diff-match-patch`.  So I'm guessing there was a reason that `checklines` was disabled, maybe you can chime in on that @jedie. 

We could shorten this even further to just:

```python
diff = dmp.diff_main(value1, value2)
```

### Resources & Relevant Links

* https://github.com/google/diff-match-patch
* `checklines` flag definition: https://github.com/google/diff-match-patch/blob/62f2e689f498f9c92dbc588c58750addec9b1654/python3/diff_match_patch.py#L85