### PR TITLE
Bugfix packaging: We use rich in production code

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ Maybe other versions are compatible, too.
 
 [comment]: <> (✂✂✂ auto generated history start ✂✂✂)
 
+* [v0.18.1](https://github.com/jedie/django-reversion-compare/compare/v0.18.0...v0.18.1)
+  * 2024-09-10 - Bugfix packaging: We use rich in production code
 * [v0.18.0](https://github.com/jedie/django-reversion-compare/compare/v0.17.0...v0.18.0)
   * 2024-09-10 - modernized code
   * 2024-09-10 - Update test matrix and requirements
@@ -239,13 +241,13 @@ Maybe other versions are compatible, too.
   * 2023-05-08 - Bugfix RegistrationError: <Model> has not been registered with django-reversion
   * 2023-05-08 - Update requirements
   * 2023-04-28 - Fix link for CBV
+
+<details><summary>Expand older history entries ...</summary>
+
 * [v0.16.1](https://github.com/jedie/django-reversion-compare/compare/v0.16.0...v0.16.1)
   * 2023-04-08 - Fix wrong README and release as v0.16.1
   * 2023-04-08 - Use new "update_req" command from manage_django_project v0.4.0
   * 2023-04-08 - Fix #195 move "diff-match-patch" not normal dependencies section
-
-<details><summary>Expand older history entries ...</summary>
-
 * [v0.16.0](https://github.com/jedie/django-reversion-compare/compare/v0.15.0...v0.16.0)
   * 2023-04-07 - tests against different Django versions
   * 2023-04-07 - Update README.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ dependencies = [
     "django",  # https://docs.djangoproject.com
     "django-reversion",  # https://github.com/etianen/django-reversion
     "diff-match-patch",  # https://github.com/diff-match-patch-python/diff-match-patch
+    #
+    # We use rich.pretty.pretty_repr() for pretty format fallback:
+    "rich",  # https://github.com/Textualize/rich
 ]
 [project.optional-dependencies]
 dev = [
@@ -25,7 +28,6 @@ dev = [
     "beautifulsoup4",   # https://pypi.org/project/beautifulsoup4/
     "freezegun",  # https://github.com/spulec/freezegun
 
-    "rich",  # https://github.com/Textualize/rich
     "colorlog",  # https://github.com/borntyping/python-colorlog
     "gunicorn",  # https://github.com/benoimyproject.wsgitc/gunicorn
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,22 @@ django-reversion==5.1.0 \
     --hash=sha256:084d4f117d9e2b4e8dfdfaad83ebb34410a03eed6071c96089e6811fdea82ad3 \
     --hash=sha256:3309821e5b6fceedcce6b6975f1a9c7fab6ae7c7d0e1276a90e345946fa0dcb8
     # via django-reversion-compare (pyproject.toml)
+markdown-it-py==3.0.0 \
+    --hash=sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1 \
+    --hash=sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb
+    # via rich
+mdurl==0.1.2 \
+    --hash=sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8 \
+    --hash=sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba
+    # via markdown-it-py
+pygments==2.18.0 \
+    --hash=sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199 \
+    --hash=sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a
+    # via rich
+rich==13.8.0 \
+    --hash=sha256:2e85306a063b9492dffc86278197a60cbece75bcb766022f3436f567cae11bdc \
+    --hash=sha256:a5ac1f1cd448ade0d59cc3356f7db7a7ccda2c8cbae9c7a90c28ff463d3e91f4
+    # via django-reversion-compare (pyproject.toml)
 sqlparse==0.5.1 \
     --hash=sha256:773dcbf9a5ab44a090f3441e2180efe2560220203dc2f8c0b0fa141e18b505e4 \
     --hash=sha256:bb6b4df465655ef332548e24f08e205afc81b9ab86cb1c45657a7ff173a3a00e

--- a/reversion_compare/__init__.py
+++ b/reversion_compare/__init__.py
@@ -4,5 +4,5 @@
 """
 
 # See https://packaging.python.org/en/latest/specifications/version-specifiers/
-__version__ = '0.18.0'
+__version__ = '0.18.1'
 __author__ = 'Jens Diemer <django-reversion-compare@jensdiemer.de>'


### PR DESCRIPTION
We use rich.pretty.pretty_repr() for pretty format fallback in `compare.CompareObject._obj_repr()` so it's needed to be installed: Move it from `dev` to `normal` requirements.