### PR TITLE
Introduce dataclasses for structured multi-value returns

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Maybe other versions are compatible, too.
 [comment]: <> (✂✂✂ auto generated history start ✂✂✂)
 
 * [**dev**](https://github.com/jedie/django-reversion-compare/compare/v0.20.0...main)
+  * 2026-08-07 - Introduce dataclasses for structured multi-value returns
   * 2026-08-07 - Optimize settings lookup
   * 2026-08-06 - Replace bare assert with explicit raises
   * 2026-08-06 - prefere usage of ./manage.py

--- a/reversion_compare/admin.py
+++ b/reversion_compare/admin.py
@@ -164,7 +164,7 @@ class BaseCompareVersionAdmin(CompareMixin, VersionAdmin):
         version2 = nav['version2']
 
         try:
-            compare_data, has_unfollowed_fields = self.compare(obj, version1, version2)
+            compare_result = self.compare(obj, version1, version2)
         except RevertError as err:
             logger.exception('Fallback compare caused')
             # A old version can't be loaded.
@@ -175,8 +175,8 @@ class BaseCompareVersionAdmin(CompareMixin, VersionAdmin):
 
         context = self._build_base_context(request, obj, version1, version2)
         context.update({
-            'compare_data': compare_data,
-            'has_unfollowed_fields': has_unfollowed_fields,
+            'compare_data': compare_result.diff,
+            'has_unfollowed_fields': compare_result.has_unfollowed_fields,
         })
         context.update(nav)  # merges next_url / prev_url if present
         context.update(extra_context or {})

--- a/reversion_compare/compare.py
+++ b/reversion_compare/compare.py
@@ -8,6 +8,7 @@
     :license: GNU GPL v3 or above, see LICENSE for more details.
 """
 
+import dataclasses
 import datetime
 import decimal
 import logging
@@ -37,6 +38,13 @@ class FieldVersionDoesNotExist:
 
 
 DOES_NOT_EXIST = FieldVersionDoesNotExist()
+
+
+@dataclasses.dataclass
+class ManyToSomethingResult:
+    versions: dict = dataclasses.field(default_factory=dict)  # {object_id: Version}
+    missing_objects: dict = dataclasses.field(default_factory=dict)  # {pk: model instance or Version}
+    deleted: list = dataclasses.field(default_factory=list)  # [Version], populated only for reverse relations
 
 
 class CompareObject:
@@ -88,7 +96,7 @@ class CompareObject:
         return choices_repr
 
     def _to_string_ManyToManyField(self):
-        return ", ".join(self._obj_repr(item) for item in self.get_many_to_many())
+        return ', '.join(self._obj_repr(item) for item in self.get_many_to_many().versions.values())
 
     def _to_string_ForeignKey(self):
         return self._obj_repr(self.get_related())
@@ -143,7 +151,7 @@ class CompareObject:
             except ObjectDoesNotExist:
                 return None
 
-    def get_reverse_foreign_key(self):
+    def get_reverse_foreign_key(self) -> ManyToSomethingResult:
         obj = self.get_object_version().object
         if self.field.related_name and hasattr(obj, self.field.related_name):
             if isinstance(self.field, models.fields.related.OneToOneRel):
@@ -165,34 +173,34 @@ class CompareObject:
                         if not isinstance(p_obj, type(obj)) and hasattr(p_obj, force_str(self.field.related_name)):
                             ids = {force_str(v.pk) for v in getattr(p_obj, force_str(self.field.related_name)).all()}
         else:
-            return {}, {}, []  # TODO: refactor that
+            return ManyToSomethingResult()
 
         # Get the related model of the current field:
         related_model = self.field.field.model
         return self.get_many_to_something(ids, related_model, is_reverse=True)
 
-    def get_many_to_many(self):
+    def get_many_to_many(self) -> ManyToSomethingResult:
         """
         returns a queryset with all many2many objects
         """
-        if self.field.get_internal_type() != "ManyToManyField" or self.value is DOES_NOT_EXIST:  # FIXME!
-            return {}, {}, []  # TODO: refactor that
+        if self.field.get_internal_type() != 'ManyToManyField' or self.value is DOES_NOT_EXIST:  # FIXME!
+            return ManyToSomethingResult()
 
         try:
             ids = frozenset(map(force_str, self.value))
         except TypeError:
             # catch errors e.g. produced by taggit's TaggableManager
             logger.exception("Can't collect m2m ids")
-            return {}, {}, []  # TODO: refactor that
+            return ManyToSomethingResult()
 
         # Get the related model of the current field:
         return self.get_many_to_something(ids, self.field.related_model)
 
-    def get_many_to_something(self, target_ids, related_model, is_reverse=False):
+    def get_many_to_something(self, target_ids, related_model, is_reverse=False) -> ManyToSomethingResult:
         if not is_registered(related_model):
             # There is no history about not registered relations, so we can't build a diff ;)
             logger.info('Related model %s has not been registered with django-reversion', related_model.__name__)
-            return {}, {}, []  # TODO: refactor that
+            return ManyToSomethingResult()
 
         # get instance of reversion.models.Revision():
         # A group of related object versions.
@@ -238,42 +246,43 @@ class CompareObject:
             else:
                 deleted = []
 
-        return versions, missing_objects_dict, deleted
+        return ManyToSomethingResult(versions=versions, missing_objects=missing_objects_dict, deleted=deleted)
 
     def get_debug(self):  # pragma: no cover
         if not settings.DEBUG:
             return
 
         result = [
-            f"field..............: {self.field!r}",
-            f"field_name.........: {self.field_name!r}",
-            f"field internal type: {self.field.get_internal_type()!r}",
-            f"field_dict.........: {self.version_record.field_dict!r}",
-            f"obj................: {self.obj!r} (pk: {self.obj.pk}, id: {id(self.obj)})",
+            f'field..............: {self.field!r}',
+            f'field_name.........: {self.field_name!r}',
+            f'field internal type: {self.field.get_internal_type()!r}',
+            f'field_dict.........: {self.version_record.field_dict!r}',
+            f'obj................: {self.obj!r} (pk: {self.obj.pk}, id: {id(self.obj)})',
             (
-                f"version............: {self.version_record!r}"
-                f" (pk: {self.version_record.pk}, id: {id(self.version_record)})"
+                f'version............: {self.version_record!r}'
+                f' (pk: {self.version_record.pk}, id: {id(self.version_record)})'
             ),
-            f"value..............: {self.value!r}",
-            f"to string..........: {self.to_string()!r}",
-            f"related............: {self.get_related()!r}",
+            f'value..............: {self.value!r}',
+            f'to string..........: {self.to_string()!r}',
+            f'related............: {self.get_related()!r}',
         ]
-        m2m_versions, missing_objects, missing_ids, _deleted = self.get_many_to_many()
-        if m2m_versions or missing_objects or missing_ids:
-            m2m = ', '.join(f'{item} ({item.type})' for item in m2m_versions)
-            result.append(f"many-to-many.......: {m2m}")
+        m2m_result = self.get_many_to_many()
+        m2m_versions, missing_objects, deleted = m2m_result.versions, m2m_result.missing_objects, m2m_result.deleted
+        if m2m_versions or missing_objects or deleted:
+            m2m = ', '.join(f'{item} ({item.type})' for item in m2m_versions.values())
+            result.append(f'many-to-many.......: {m2m}')
 
             if missing_objects:
-                result.append(f"missing m2m objects: {missing_objects!r}")
+                result.append(f'missing m2m objects: {missing_objects!r}')
             else:
-                result.append("missing m2m objects: (has no)")
+                result.append('missing m2m objects: (has no)')
 
-            if missing_ids:
-                result.append(f"missing m2m IDs....: {missing_ids!r}")
+            if deleted:
+                result.append(f'deleted m2m items..: {deleted!r}')
             else:
-                result.append("missing m2m IDs....: (has no)")
+                result.append('deleted m2m items..: (has no)')
         else:
-            result.append("many-to-many.......: (has no)")
+            result.append('many-to-many.......: (has no)')
 
         return result
 
@@ -354,10 +363,10 @@ class CompareObjects:
     def get_related(self):
         return self.compare_obj1.get_related(), self.compare_obj2.get_related()
 
-    def get_many_to_many(self):
+    def get_many_to_many(self) -> tuple[ManyToSomethingResult, ManyToSomethingResult]:
         return self.compare_obj1.get_many_to_many(), self.compare_obj2.get_many_to_many()
 
-    def get_reverse_foreign_key(self):
+    def get_reverse_foreign_key(self) -> tuple[ManyToSomethingResult, ManyToSomethingResult]:
         return self.compare_obj1.get_reverse_foreign_key(), self.compare_obj2.get_reverse_foreign_key()
 
     def get_m2o_change_info(self):
@@ -381,9 +390,16 @@ class CompareObjects:
     # Abstract Many-to-Something (either -many or -one) as both
     # many2many and many2one relationships looks the same from the referred object.
     def get_m2s_change_info(self, obj1_data, obj2_data):
-
-        result_dict1, missing_objects_dict1, deleted1 = obj1_data
-        result_dict2, missing_objects_dict2, _deleted2 = obj2_data
+        result_dict1, missing_objects_dict1, deleted1 = (
+            obj1_data.versions,
+            obj1_data.missing_objects,
+            obj1_data.deleted,
+        )
+        result_dict2, missing_objects_dict2, _deleted2 = (
+            obj2_data.versions,
+            obj2_data.missing_objects,
+            obj2_data.deleted,
+        )
 
         # Create same_items, removed_items, added_items with related m2m items
         changed_items = []

--- a/reversion_compare/mixins.py
+++ b/reversion_compare/mixins.py
@@ -8,6 +8,8 @@
     :license: GNU GPL v3 or above, see LICENSE for more details.
 """
 
+import dataclasses
+
 from django.conf import settings
 from django.db import models
 from django.http import Http404
@@ -19,6 +21,12 @@ from django.utils.http import urlencode
 from reversion_compare.compare import CompareObjects
 from reversion_compare.forms import SelectDiffForm
 from reversion_compare.helpers import html_diff
+
+
+@dataclasses.dataclass
+class CompareResult:
+    diff: list
+    has_unfollowed_fields: bool
 
 
 class CompareMixin:
@@ -120,7 +128,7 @@ class CompareMixin:
 
         return result
 
-    def compare(self, obj, version1, version2):
+    def compare(self, obj, version1, version2) -> CompareResult:
         """
         Create a generic html diff from the obj between version1 and version2:
 
@@ -176,7 +184,7 @@ class CompareMixin:
             html = self._get_compare(obj_compare)
             diff.append({"field": field, "is_related": is_related, "follow": follow, "diff": html})
 
-        return diff, has_unfollowed_fields
+        return CompareResult(diff=diff, has_unfollowed_fields=has_unfollowed_fields)
 
     def fallback_compare(self, obj_compare):
         """
@@ -213,8 +221,8 @@ class CompareMethodsMixin:
     def simple_compare_ManyToManyField(self, obj_compare):
         """ comma separated list of all m2m objects """
         m2m1, m2m2 = obj_compare.get_many_to_many()
-        old = ", ".join(force_str(item) for item in m2m1)
-        new = ", ".join(force_str(item) for item in m2m2)
+        old = ", ".join(force_str(item) for item in m2m1.versions.values())
+        new = ", ".join(force_str(item) for item in m2m2.versions.values())
         html = html_diff(old, new)
         return html
 

--- a/reversion_compare/tests/test_person_pet_models.py
+++ b/reversion_compare/tests/test_person_pet_models.py
@@ -16,6 +16,8 @@
 from reversion import create_revision, is_registered, set_comment
 from reversion.models import Revision, Version
 
+from reversion_compare.compare import CompareObjects
+from reversion_compare.mixins import CompareMethodsMixin
 from reversion_compare_project.models import Person, Pet
 from reversion_compare_project.utils.fixtures import Fixtures
 
@@ -149,6 +151,16 @@ class PersonPetModelTest(BaseTestCase):
             # All fields are under reversion control:
             ' not under reversion control.' 'class="follow"',
         )
+
+    def test_simple_compare_m2m(self):
+        queryset = Version.objects.get_for_object(self.person)
+        version1 = queryset[1]
+        version2 = queryset[0]
+        pets_field = Person._meta.get_field('pets')
+        obj_compare = CompareObjects(pets_field, 'pets', self.person, version1, version2, is_reversed=False)
+        html = CompareMethodsMixin().simple_compare_ManyToManyField(obj_compare)
+        self.assertIn('always the same pet', html)
+        self.assertIn('<del>would be removed pet', html)
 
     def test_m2m_not_changed(self):
         with create_revision():

--- a/reversion_compare/views.py
+++ b/reversion_compare/views.py
@@ -51,12 +51,12 @@ class HistoryCompareDetailView(CompareMixin, CompareMethodsMixin, DetailView):
             version1 = nav['version1']
             version2 = nav['version2']
 
-            compare_data, has_unfollowed_fields = self.compare(obj, version1, version2)
+            result = self.compare(obj, version1, version2)
 
             context.update(
                 {
-                    'compare_data': compare_data,
-                    'has_unfollowed_fields': has_unfollowed_fields,
+                    'compare_data': result.diff,
+                    'has_unfollowed_fields': result.has_unfollowed_fields,
                 }
             )
             context.update(nav)  # merges version1, version2, next_url, prev_url


### PR DESCRIPTION
Replace bare tuple returns with typed dataclasses to eliminate positional fragility and remove four `{}, {}, []  # TODO: refactor that` sentinels.

- `ManyToSomethingResult` (compare.py): wraps `versions`, `missing_objects`, and `deleted`; default-factory fields allow `ManyToSomethingResult()` as the empty sentinel. Callers unpack via named attributes into the original local variable names.
- `CompareResult` (mixins.py): wraps `diff` and `has_unfollowed_fields`; returned by `CompareMixin.compare()` and consumed in admin and CBV views.

Also fixes two latent bugs in `CompareObject`:
- `_to_string_ManyToManyField` was iterating the 3-tuple itself instead of the versions dict values.
- `get_debug` was unpacking 4 names from a 3-tuple (would crash at runtime), and referenced a non-existent `missing_ids` field instead of `deleted`.

Adds a unit test for `simple_compare_ManyToManyField`, which was previously unreachable because the method is inactive by default.