### PR TITLE
Simplify compare_FileField and extend AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,3 +85,21 @@ Files matching `reversion_compare/tests/*.snapshot.html` are auto-generated. Run
 them after intentional HTML changes.
 
 run tests by call `manage.py test` from the project root.
+
+## Code Style Rules
+
+- Do not remove existing code comments, even when simplifying or restructuring the surrounding code.
+  If a comment is still valid after the change, keep it verbatim.
+- Always bind intermediate values to named local variables before further processing them.
+  Do not use inline expressions, because Django tracebacks show all local variables per frame,
+  so named locals aid debugging.
+
+## After Making Code Changes
+
+After every code change, always complete the full verification cycle before stopping:
+
+1. Run the linter: `./manage.py code_style`
+2. Run the tests: `./manage.py test`
+
+Do not stop or report the task as done until both pass cleanly. Never assume a change is correct
+without running the tests.

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Maybe other versions are compatible, too.
 [comment]: <> (✂✂✂ auto generated history start ✂✂✂)
 
 * [**dev**](https://github.com/jedie/django-reversion-compare/compare/v0.20.0...main)
+  * 2026-08-10 - Simplify compare_FileField and extend AGENTS.md
   * 2026-08-10 - Simplify _get_compare lookup loop
   * 2026-08-07 - Clean up CompareObject equality logic
   * 2026-08-07 - Introduce dataclasses for structured multi-value returns

--- a/reversion_compare/mixins.py
+++ b/reversion_compare/mixins.py
@@ -225,18 +225,9 @@ class CompareMethodsMixin:
     def compare_FileField(self, obj_compare):
         value1 = obj_compare.value1
         value2 = obj_compare.value2
-
         # FIXME: Needed to not get 'The 'file' attribute has no file associated with it.'
-        if value1:
-            value1 = value1.url
-        else:
-            value1 = None
-
-        if value2:
-            value2 = value2.url
-        else:
-            value2 = None
-
+        value1 = value1.url if value1 else None
+        value2 = value2.url if value2 else None
         return self.generic_add_remove(value1, value2, value1, value2)
 
     def compare_DateTimeField(self, obj_compare):


### PR DESCRIPTION
Replace verbose if/else blocks in `compare_FileField` with ternary expressions while preserving intermediate variable bindings for Django traceback visibility.

Extend AGENTS.md with code style rules (keep comments, named locals) and a post-change verification workflow (lint + test).